### PR TITLE
Extend configuration to allow routing based on labels

### DIFF
--- a/src/action.ml
+++ b/src/action.ml
@@ -59,7 +59,7 @@ let print_push_routing rules =
     Stdio.printf " -> #%s\n%!" rule.webhook.channel;
   end
 
-let print_pr_routing rules =
+let print_label_routing rules =
   let show_match l = String.concat ~sep:" or " @@ List.map ~f:(fun s -> s ^ "*") l in
   rules |> List.iter ~f:begin fun rule ->
     begin match rule.labels, rule.ignore with

--- a/src/notabot.atd
+++ b/src/notabot.atd
@@ -35,7 +35,7 @@ type prefix_rule = {
   webhook : webhook;
 }
 
-type pr_rule = {
+type label_rule = {
   labels : string list;
   ignore : string list;
   webhook : webhook;
@@ -43,7 +43,7 @@ type pr_rule = {
 
 type config = {
   push_rules : prefix_rule list;
-  pr_rules : pr_rule list;
+  pr_rules : label_rule list;
   ?gh_webhook_secret: string option; (* if not specified - signatures will not be checked *)
   ?main_branch_name: string option; (* used to filter out notifications about merges of main branch into other branches *)
 }

--- a/src/notabot.ml
+++ b/src/notabot.ml
@@ -17,7 +17,7 @@ let get_config () =
   Stdio.print_endline "Using push routing:";
   Action.print_push_routing cfg.push_rules;
   Stdio.print_endline "Using pull request routing:";
-  Action.print_pr_routing cfg.pr_rules;
+  Action.print_label_routing cfg.pr_rules;
   cfg
 
 let main port =


### PR DESCRIPTION
- added a new type pr_rule and a new field in config in notabot.atd
- set the default rule to be prefix_rule (for now)
- add print_pr_routing in action.ml