### PR TITLE
Rename `allow` to `match` for prefix/label rules in config file

### DIFF
--- a/documentation/config_docs.md
+++ b/documentation/config_docs.md
@@ -43,25 +43,25 @@ Refer [here](https://docs.github.com/en/free-pro-team@latest/developers/webhooks
     "default_channel": "default",
     "rules": [
         {
-            "allow": [
+            "match": [
                 "backend"
             ],
             "channel": "backend"
         },
         {
-            "allow": [
+            "match": [
                 "aa"
             ],
             "channel": "aa-git"
         },
         {
-            "allow": [
+            "match": [
                 "siren"
             ],
             "channel": "siren"
         },
         {
-            "allow": [],
+            "match": [],
             "ignore": [
                 "backend",
                 "aa",
@@ -80,12 +80,12 @@ Refer [here](https://docs.github.com/en/free-pro-team@latest/developers/webhooks
 
 ### Label Rule
 
-A **label rule** specifies whether or not a Slack channel should be notified, based on the labels present in the given payload. For each rule, `ignore` is a blacklist of labels that should not notify the rule's channel, and `allow` is a whitelist of labels that should. If a label exists in both lists, the `ignore` list takes precedence. If an empty `ignore` list is provided, nothing is ignored. If an empty `allow` list is provided, everything is allowed. Both are optional; if neither are provided, the rule will always generate a notification for its channel.
+A **label rule** specifies whether or not a Slack channel should be notified, based on the labels present in the given payload. For each rule, `ignore` is a blacklist of labels that should not notify the rule's channel, and `match` is a whitelist of labels that should. If a label exists in both lists, the `ignore` list takes precedence. If an empty `ignore` list is provided, nothing is ignored. If an empty `match` list is provided, everything is matched. Both are optional; if neither are provided, the rule will always generate a notification for its channel.
 
 | value | description | optional | default |
 |-|-|-|-|
-| `allow` | if notifications match any label in this list, they should be routed to the channel | Yes | all labels allowed if no list provided |
-| `ignore` | if notifications match any label in this list, they shouldn't be routed to the channel (even if they match any allow labels) | Yes | - |
+| `match` | if notifications have any label in this list, they should be routed to the channel | Yes | all labels matched if no list provided |
+| `ignore` | if notifications have any label in this list, they shouldn't be routed to the channel (even if they have any `match` labels) | Yes | - |
 | `channel` | channel to use as webhook if the rule is matched | No | - |
 
 ## Prefix Options
@@ -98,13 +98,13 @@ A **label rule** specifies whether or not a Slack channel should be notified, ba
     "default_channel": "default",
     "rules": [
         {
-            "allow": [
+            "match": [
                 "backend/api"
             ],
             "channel": "aa"
         },
         {
-            "allow": [
+            "match": [
                 "backend/megaindex",
                 "backend/ahrefskit"
             ],
@@ -119,12 +119,12 @@ A **label rule** specifies whether or not a Slack channel should be notified, ba
 
 ### Prefix Rule
 
-A **prefix rule** specifies whether or not a Slack channel should be notified, based on the filenames present in the commits associated with the given payload. The semantics for the `allow` and `ignore` fields are the same as those for label rules (see above).
+A **prefix rule** specifies whether or not a Slack channel should be notified, based on the filenames present in the commits associated with the given payload. The semantics for the `match` and `ignore` fields are the same as those for label rules (see above).
 
 | value | description | optional | default |
 |-|-|-|-|
-| `allow` | if commit files match any prefix in this list, they should be routed to the channel | Yes | all prefixes allowed if no list provided |
-| `ignore` | if commit files match any prefix in this list, they shouldn't be routed to the channel (even if they match any allow prefixes) | Yes | - |
+| `match` | if commit files have any prefix in this list, they should be routed to the channel | Yes | all prefixes matched if no list provided |
+| `ignore` | if commit files have any prefix in this list, they shouldn't be routed to the channel (even if they have any `match` prefixes) | Yes | - |
 | `channel` | channel to use as webhook if the rule is matched | No | - |
 
 ## Status Options

--- a/lib/rule.atd
+++ b/lib/rule.atd
@@ -64,7 +64,7 @@ type status_rule = {
    ignore should be ["some/other"] 
 *)
 type prefix_rule = {
-  ?allow : string list nullable;
+  ?allow <json name="match"> : string list nullable;
   ?ignore : string list nullable;
   channel_name <json name="channel"> : string;
 }
@@ -73,7 +73,7 @@ type prefix_rule = {
    and present in the allow list. Both `allow` and `ignore` are optional. If `allow`
    is undefined, then the rule matches all payloads. *)
 type label_rule = {
-  ?allow : string list nullable;
+  ?allow <json name="match"> : string list nullable;
   ?ignore : string list nullable;
   channel_name <json name="channel"> : string;
 }

--- a/test/notabot.json
+++ b/test/notabot.json
@@ -22,19 +22,19 @@
         "default_channel": "default",
         "rules": [
             {
-                "allow": [
+                "match": [
                     "backend/api"
                 ],
                 "channel": "aa"
             },
             {
-                "allow": [
+                "match": [
                     "backend/api/longest"
                 ],
                 "channel": "longest-aa"
             },
             {
-                "allow": [
+                "match": [
                     "backend/megaindex",
                     "backend/ahrefskit"
                 ],
@@ -49,19 +49,19 @@
         "default_channel": "default",
         "rules": [
             {
-                "allow": [
+                "match": [
                     "backend"
                 ],
                 "channel": "backend"
             },
             {
-                "allow": [
+                "match": [
                     "aa"
                 ],
                 "channel": "aa-git"
             },
             {
-                "allow": [
+                "match": [
                     "siren"
                 ],
                 "channel": "siren"


### PR DESCRIPTION
## Description of the task

Rename `allow` to `match` for prefix/label rules in config file

## References

- https://git.ahrefs.com/ahrefs/monorepo/pull/7486#pullrequestreview-28915
