### PR TITLE
Project owners

### DIFF
--- a/documentation/config_docs.md
+++ b/documentation/config_docs.md
@@ -23,6 +23,9 @@ Refer [here](https://docs.github.com/en/free-pro-team@latest/developers/webhooks
     },
     "status_rules": {
         ...
+    },
+    "project_owners": {
+        ...
     }
 }
 ```
@@ -33,6 +36,7 @@ Refer [here](https://docs.github.com/en/free-pro-team@latest/developers/webhooks
 | `label_rules` | label rules config object | required field |
 | `prefix_rules` | prefix rules config object | required field |
 | `status_rules` | status rules config object | all status notifications are ignored |
+| `project_owners` | project owners config object | no project owners are defined |
 
 ## Label Options
 
@@ -236,5 +240,27 @@ You can optionally provide a **status condition** to specify additional requirem
         "field": "context" | "description" | "target_url",
         "re": string // a regular expression
     }
+}
+```
+
+## Project Owners
+
+In GitHub, ["code owners"](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) are the users/teams whose review is automatically requested when a PR modifying code in a given directory is opened. **Project owners** behave similarly, with two differences.
+
+- Owners are defined _per PR label_, instead of _per directory_ (or directory pattern)
+- Definitions should be placed in the per-repo Monorobot configuration file, instead of a `CODEOWNERS` file
+
+The syntax for listing users is `username`. For teams, it is `org/team-name`.
+
+Note that the owner of the personal access token cannot be a project owner, as GitHub disallows a user from self-requesting a review. Consider provisioning a separate bot user, or authenticating using a [GitHub App](https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#accessing-api-endpoints-as-a-github-app) instead.
+
+```json
+{
+    ...,
+    "project_owners": {
+        "Label 1": ["user1", "user2", "org/team1"],
+        "Label 2": ["org/team2", "user3"]
+    },
+    ...
 }
 ```

--- a/documentation/config_docs.md
+++ b/documentation/config_docs.md
@@ -258,8 +258,16 @@ Note that the owner of the personal access token cannot be a project owner, as G
 {
     ...,
     "project_owners": {
-        "Label 1": ["user1", "user2", "org/team1"],
-        "Label 2": ["org/team2", "user3"]
+        "rules": [
+            {
+                "label": "Label 1",
+                "owners": ["user1", "user2", "org/team1"]
+            },
+            {
+                "label": "Label 2",
+                "owners": ["org/team2", "user3"]
+            }
+        ]
     },
     ...
 }

--- a/documentation/config_docs.md
+++ b/documentation/config_docs.md
@@ -250,6 +250,10 @@ In GitHub, ["code owners"](https://docs.github.com/en/repositories/managing-your
 - Owners are defined _per PR label_, instead of _per directory_ (or directory pattern)
 - Definitions should be placed in the per-repo Monorobot configuration file, instead of a `CODEOWNERS` file
 
+Draft PR behavior is similar to code owners. From GitHub documentation:
+
+> Code owners are not automatically requested to review draft pull requests. [...] When you mark a draft pull request as ready for review, code owners are automatically notified.
+
 The syntax for listing users is `username`. For teams, it is `org/team-name`.
 
 Note that the owner of the personal access token cannot be a project owner, as GitHub disallows a user from self-requesting a review. Consider provisioning a separate bot user, or authenticating using a [GitHub App](https://docs.github.com/en/developers/apps/building-github-apps/authenticating-with-github-apps#accessing-api-endpoints-as-a-github-app) instead.

--- a/lib/action.ml
+++ b/lib/action.ml
@@ -208,6 +208,21 @@ module Action (Github_api : Api.Github) (Slack_api : Api.Slack) = struct
       if config_was_modified then fetch_config () else Lwt.return @@ Ok ()
     | _ -> Lwt.return @@ Ok ()
 
+  let do_github_tasks ctx (req : Github.t) =
+    let cfg = Context.get_config_exn ctx in
+    match req with
+    | Github.Pull_request { action = Labeled; pull_request; repository; number; _ } ->
+      begin
+        match Github.get_project_owners pull_request.labels cfg.project_owners with
+        | Some reviewers ->
+          ( match%lwt Github_api.request_reviewers ~ctx ~repo:repository ~number ~reviewers with
+          | Ok () -> Lwt.return_unit
+          | Error e -> action_error e
+          )
+        | None -> Lwt.return_unit
+      end
+    | _ -> Lwt.return_unit
+
   let process_github_notification (ctx : Context.t) headers body =
     try%lwt
       let secrets = Context.get_secrets_exn ctx in
@@ -218,7 +233,7 @@ module Action (Github_api : Api.Github) (Slack_api : Api.Slack) = struct
         | Error e -> action_error e
         | Ok () ->
           let%lwt notifications = generate_notifications ctx payload in
-          let%lwt () = send_notifications ctx notifications in
+          let%lwt () = Lwt.join [ send_notifications ctx notifications; do_github_tasks ctx payload ] in
           ( match ctx.state_filepath with
           | None -> Lwt.return_unit
           | Some path ->

--- a/lib/action.ml
+++ b/lib/action.ml
@@ -211,7 +211,7 @@ module Action (Github_api : Api.Github) (Slack_api : Api.Slack) = struct
   let do_github_tasks ctx (req : Github.t) =
     let cfg = Context.get_config_exn ctx in
     let project_owners (pull_request : pull_request) repository number =
-      match Github.get_project_owners pull_request.labels cfg.project_owners with
+      match Github.get_project_owners pull_request cfg.project_owners with
       | Some reviewers ->
         ( match%lwt Github_api.request_reviewers ~ctx ~repo:repository ~number ~reviewers with
         | Ok () -> Lwt.return_unit

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -10,6 +10,13 @@ module type Github = sig
   val get_pull_request : ctx:Context.t -> repo:repository -> number:int -> (pull_request, string) Result.t Lwt.t
 
   val get_issue : ctx:Context.t -> repo:repository -> number:int -> (issue, string) Result.t Lwt.t
+
+  val request_reviewers
+    :  ctx:Context.t ->
+    repo:repository ->
+    number:int ->
+    reviewers:request_reviewers_req ->
+    (unit, string) Result.t Lwt.t
 end
 
 module type Slack = sig

--- a/lib/api_local.ml
+++ b/lib/api_local.ml
@@ -22,6 +22,8 @@ module Github : Api.Github = struct
   let get_pull_request ~ctx:_ ~repo:_ ~number:_ = Lwt.return @@ Error "undefined for local setup"
 
   let get_issue ~ctx:_ ~repo:_ ~number:_ = Lwt.return @@ Error "undefined for local setup"
+
+  let request_reviewers ~ctx:_ ~repo:_ ~number:_ ~reviewers:_ = Lwt.return @@ Error "undefined for local setup"
 end
 
 module Slack_base : Api.Slack = struct

--- a/lib/config.atd
+++ b/lib/config.atd
@@ -1,6 +1,7 @@
 type status_rule <ocaml from="Rule"> = abstract
 type prefix_rule <ocaml from="Rule"> = abstract
 type label_rule <ocaml from="Rule"> = abstract
+type 'v map_as_object <ocaml from="Common"> = abstract
 
 (* This type of rule is used for CI build notifications. *)
 type status_rules = {
@@ -28,6 +29,7 @@ type config = {
   prefix_rules : prefix_rules;
   label_rules : label_rules;
   ~status_rules <ocaml default="{allowed_pipelines = Some []; rules = []}"> : status_rules;
+  ~project_owners <ocaml default="Common.StringMap.empty"> : string list map_as_object;
   ?main_branch_name : string nullable; (* the name of the main branch; used to filter out notifications about merges of main branch into other branches *)
 }
 

--- a/lib/config.atd
+++ b/lib/config.atd
@@ -1,7 +1,7 @@
 type status_rule <ocaml from="Rule"> = abstract
 type prefix_rule <ocaml from="Rule"> = abstract
 type label_rule <ocaml from="Rule"> = abstract
-type 'v map_as_object <ocaml from="Common"> = abstract
+type project_owners_rule <ocaml from="Rule"> = abstract
 
 (* This type of rule is used for CI build notifications. *)
 type status_rules = {
@@ -23,13 +23,18 @@ type label_rules = {
   rules: label_rule list;
 }
 
+(* This type of rule is used for routing PR review requests to users. *)
+type project_owners = {
+  rules: project_owners_rule list;
+}
+
 (* This is the structure of the repository configuration file. It should be at the
    root of the monorepo, on the main branch. *)
 type config = {
   prefix_rules : prefix_rules;
   label_rules : label_rules;
   ~status_rules <ocaml default="{allowed_pipelines = Some []; rules = []}"> : status_rules;
-  ~project_owners <ocaml default="Common.StringMap.empty"> : string list map_as_object;
+  ~project_owners <ocaml default="{rules = []}"> : project_owners;
   ?main_branch_name : string nullable; (* the name of the main branch; used to filter out notifications about merges of main branch into other branches *)
 }
 

--- a/lib/github.atd
+++ b/lib/github.atd
@@ -269,6 +269,11 @@ type commit_comment_notification = {
   sender: github_user;
 }
 
+type request_reviewers_req = {
+  reviewers : string list;
+  team_reviewers : string list;
+}
+
 (* other generic events *)
 type event_notification = {
   repository: repository

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -140,12 +140,8 @@ let gh_link_of_string url_str =
     end
   | _ | (exception Re2.Exceptions.Regex_match_failed _) -> None
 
-let get_project_owners (labels : label list) project_owners_map =
-  List.fold_left labels ~init:[] ~f:(fun acc label ->
-    match Map.find_multi project_owners_map label.name with
-    | [] -> acc
-    | reviewers -> List.rev_append reviewers acc
-  )
+let get_project_owners (labels : label list) ({ rules } : Config_t.project_owners) =
+  List.fold_left labels ~init:[] ~f:(fun acc l -> List.rev_append (Rule.Project_owners.match_rules l ~rules) acc)
   |> List.dedup_and_sort ~compare:String.compare
   |> List.partition_map ~f:(fun reviewer ->
        try

--- a/lib/rule.atd
+++ b/lib/rule.atd
@@ -80,3 +80,12 @@ type label_rule = {
   ?ignore : string list nullable;
   channel_name <json name="channel"> : string;
 }
+
+(* Requests reviews from [owners] if a PR is labeled with [label]. Owner format:
+   - users: "username"
+   - teams: "org/team"
+*)
+type project_owners_rule = {
+  label: string;
+  owners: string list;
+}

--- a/lib/rule.ml
+++ b/lib/rule.ml
@@ -125,3 +125,10 @@ module Label = struct
          Stdio.printf " -> #%s\n%!" rule.channel_name
        )
 end
+
+module Project_owners = struct
+  let match_rules (l : Github_t.label) ~rules =
+    match List.find rules ~f:(fun { label; _ } -> String.equal label l.name) with
+    | Some { owners = []; _ } | None -> []
+    | Some { owners; _ } -> owners
+end


### PR DESCRIPTION
## Description of the task

Adds something similar to [CODEOWNERS](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) except that the owners are defined per label instead of per directory.

- Uses API to [request reviewers for a PR](https://docs.github.com/en/rest/reference/pulls#request-reviewers-for-a-pull-request)
- Owners are defined in `.monorobot.json` along with Slack routing rules

Caveats
- As noted in docs, the owner of the personal access token cannot be a project owner, as GitHub disallows a user from self-requesting a review. We might want to look into authenticating as a GitHub App (i.e., not as any particular user).
- When multiple labels are added at once, a GH event is created for each one, so the review request API is queried redundantly. Functionally this is fine for now; GH will ignore subsequent requests. We should really add a way to pool incoming events, though, for this and other reasons.

## References

- existing issue: #117 
