### PR TITLE
CI status updates sent as direct message to author of commit

### DIFF
--- a/documentation/config_docs.md
+++ b/documentation/config_docs.md
@@ -163,7 +163,7 @@ The following takes place when a status notification is received.
    - `failure`: `allow`
    - `error`: `allow`
    - `success`: `allow_once`
-1. For those payloads allowed by step 1, if it isn't a main branch build notification, route to the default channel to reduce spam in topic channels. Otherwise, check the notification commit's files according to the prefix rules.
+1. For those payloads allowed by step 1, if it isn't a main branch build notification, query for a slack profile that matches the author of the commit and direct message them. If no profile is found, route to default channel to reduce spam in topic channels. Otherwise, check the notification commit's files according to the prefix rules.
 
 Internally, the bot keeps track of the status of the last allowed payload, for a given pipeline and branch. This information is used to evaluate the status rules (see below).
 

--- a/lib/action.ml
+++ b/lib/action.ml
@@ -100,7 +100,7 @@ module Action (Github_api : Api.Github) (Slack_api : Api.Slack) = struct
     let rules = cfg.status_rules.rules in
     let action_on_match (branches : branch list) =
       let%lwt default =
-        match%lwt Slack_api.lookup_user ~ctx ~email:n.commit.commit.author.email with
+        match%lwt Slack_api.lookup_user ~ctx ~cfg ~email:n.commit.commit.author.email with
         (* To send a DM, channel parameter is set to the user id of the recipient *)
         | Ok res -> Lwt.return [ res.user.id ]
         | Error e ->

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -18,7 +18,7 @@ module type Github = sig
 end
 
 module type Slack = sig
-  val lookup_user : ctx:Context.t -> email:string -> lookup_user_res slack_response Lwt.t
+  val lookup_user : ctx:Context.t -> cfg:Config_t.config -> email:string -> lookup_user_res slack_response Lwt.t
   val send_notification : ctx:Context.t -> msg:post_message_req -> unit slack_response Lwt.t
 
   val send_chat_unfurl

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -19,7 +19,6 @@ end
 
 module type Slack = sig
   val lookup_user : ctx:Context.t -> email:string -> lookup_user_res slack_response Lwt.t
-
   val send_notification : ctx:Context.t -> msg:post_message_req -> unit slack_response Lwt.t
 
   val send_chat_unfurl

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -18,6 +18,8 @@ module type Github = sig
 end
 
 module type Slack = sig
+  val lookup_user : ctx:Context.t -> email:string -> lookup_user_res slack_response Lwt.t
+
   val send_notification : ctx:Context.t -> msg:post_message_req -> unit slack_response Lwt.t
 
   val send_chat_unfurl

--- a/lib/api_local.ml
+++ b/lib/api_local.ml
@@ -52,7 +52,7 @@ end
 
 (** The base implementation for local check payload debugging and mocking tests *)
 module Slack_base : Api.Slack = struct
-  let lookup_user ~ctx:_ ~email:_ = Lwt.return @@ Error "undefined for local setup"
+  let lookup_user ~ctx:_ ~cfg:_ ~email:_ = Lwt.return @@ Error "undefined for local setup"
   let send_notification ~ctx:_ ~msg:_ = Lwt.return @@ Error "undefined for local setup"
   let send_chat_unfurl ~ctx:_ ~channel:_ ~ts:_ ~unfurls:_ () = Lwt.return @@ Error "undefined for local setup"
   let send_auth_test ~ctx:_ () = Lwt.return @@ Error "undefined for local setup"
@@ -62,7 +62,8 @@ end
 module Slack : Api.Slack = struct
   include Slack_base
 
-  let lookup_user ~ctx:_ ~email =
+  let lookup_user ~ctx:_ ~(cfg : Config_t.config) ~email =
+    let email = List.Assoc.find cfg.user_mappings ~equal:String.equal email |> Option.value ~default:email in
     let mock_user =
       {
         Slack_t.id = sprintf "id[%s]" email;

--- a/lib/api_local.ml
+++ b/lib/api_local.ml
@@ -63,12 +63,14 @@ module Slack : Api.Slack = struct
   include Slack_base
 
   let lookup_user ~ctx:_ ~email =
-    let msg = {Slack_t.email = email} in
-    let json = msg |> Slack_j.string_of_lookup_user_req  |> Yojson.Basic.from_string |> Yojson.Basic.pretty_to_string in
-    Stdio.printf "looking up slack user by email %s\n" email;
-    Stdio.printf "%s\n" json;
-    let mock_user = {Slack_t.id = "mock_id"; name="mock_name"; real_name="mock_real_name"} in
-    let mock_response = {Slack_t.user = mock_user} in
+    let mock_user =
+      {
+        Slack_t.id = sprintf "id[%s]" email;
+        name = sprintf "name[%s]" email;
+        real_name = sprintf "real_name[%s]" email;
+      }
+    in
+    let mock_response = { Slack_t.user = mock_user } in
     Lwt.return @@ Ok mock_response
 
   let send_notification ~ctx:_ ~msg =

--- a/lib/api_remote.ml
+++ b/lib/api_remote.ml
@@ -118,21 +118,11 @@ module Slack : Api.Slack = struct
     ignore (Slack_j.read_ok_res s l)
 
   (** [lookup_user ctx email] queries slack for a user profile with [email] *)
-  let lookup_user ~(ctx: Context.t) ~email =
-    log#info "looking up %s\n" email;
-    let build_error e = fmt_error "%s\nfailed to lookup Slack user" e in
-    let secrets = Context.get_secrets_exn ctx in
-    match secrets.slack_access_token with
-    | None -> Lwt.return @@ build_error @@ sprintf "no token configured to lookup user email %s" email
-    | Some access_token ->
-      let headers = [ bearer_token_header access_token ] in
-      let data = {Slack_t.email = email} |> Slack_j.string_of_lookup_user_req in
-      let body = `Raw ("application/json", data) in
-      let url ="https://slack.com/api/users.lookupByEmail" in
-      log#info "data: %s" data;
-      match%lwt slack_api_request ~body ~headers `GET url Slack_j.read_lookup_user_res with
-      | Ok res -> Lwt.return @@ Ok res
-      | Error e -> Lwt.return @@ build_error e
+  let lookup_user ~(ctx : Context.t) ~email =
+    let data = Slack_j.string_of_lookup_user_req { Slack_t.email } in
+    request_token_auth ~name:"lookup user by email"
+      ~body:(`Raw ("application/json", data))
+      ~ctx `GET "users.lookupByEmail" Slack_j.read_lookup_user_res
 
   (** [send_notification ctx msg] notifies [msg.channel] with the payload [msg];
       uses web API with access token if available, or with webhook otherwise *)

--- a/lib/api_remote.ml
+++ b/lib/api_remote.ml
@@ -117,8 +117,10 @@ module Slack : Api.Slack = struct
     (* must read whole response to update lexer state *)
     ignore (Slack_j.read_ok_res s l)
 
-  (** [lookup_user ctx email] queries slack for a user profile with [email] *)
-  let lookup_user ~(ctx : Context.t) ~email =
+  (** [lookup_user cfg email] queries slack for a user profile with [email] *)
+  let lookup_user ~(ctx : Context.t) ~(cfg : Config_t.config) ~email =
+    (* Check if config holds the Github to Slack email mapping  *)
+    let email = List.Assoc.find cfg.user_mappings ~equal:String.equal email |> Option.value ~default:email in
     let data = Slack_j.string_of_lookup_user_req { Slack_t.email } in
     request_token_auth ~name:"lookup user by email"
       ~body:(`Raw ("application/json", data))

--- a/lib/config.atd
+++ b/lib/config.atd
@@ -37,6 +37,7 @@ type config = {
   ~project_owners <ocaml default="{rules = []}"> : project_owners;
   ~ignored_users <ocaml default="[]">: string list; (* list of ignored users *)
   ?main_branch_name : string nullable; (* the name of the main branch; used to filter out notifications about merges of main branch into other branches *)
+  ~user_mappings <ocaml default="[]">: (string * string) list <json repr="object"> (* list of github to slack profile mappings *)
 }
 
 (* This specifies the Slack webhook to query to post to the channel with the given name *)

--- a/lib/slack.atd
+++ b/lib/slack.atd
@@ -67,6 +67,20 @@ type post_message_res = {
   channel: string;
 }
 
+type lookup_user_req = {
+  email: string;
+}
+
+type lookup_user_res = {
+  user: user;
+}
+
+type user = {
+  id: string;
+  name: string;
+  real_name: string;
+}
+
 type link_shared_link = {
   domain: string;
   url: string;

--- a/test/monorobot.json
+++ b/test/monorobot.json
@@ -95,5 +95,8 @@
                 "channel": "frontend-bot"
             }
         ]
+    },
+    "user_mappings": {
+        "mail@example.org": "slack_mail@example.com"
     }
 }

--- a/test/slack_payloads.expected
+++ b/test/slack_payloads.expected
@@ -497,9 +497,11 @@ will notify #longest-a1
 }
 ===== file ../mock_payloads/status.cancelled_test.json =====
 ===== file ../mock_payloads/status.failure_test.json =====
-will notify #default
+looking up slack user by email mail@example.org
+{ "email": "mail@example.org" }
+will notify #mock_id
 {
-  "channel": "default",
+  "channel": "mock_id",
   "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2/builds/2|buildkite/pipeline2>: failure",
   "attachments": [
     {
@@ -518,11 +520,15 @@ will notify #default
 ===== file ../mock_payloads/status.merge_develop.json =====
 ===== file ../mock_payloads/status.pending_test.json =====
 ===== file ../mock_payloads/status.state_hide_success_test.json =====
+looking up slack user by email mail@example.org
+{ "email": "mail@example.org" }
 ===== file ../mock_payloads/status.state_hide_success_test_disallowed_pipeline.json =====
 ===== file ../mock_payloads/status.success_public_repo_no_buildkite.json =====
-will notify #default
+looking up slack user by email 21031067+Codertocat@users.noreply.github.com
+{ "email": "21031067+Codertocat@users.noreply.github.com" }
+will notify #mock_id
 {
-  "channel": "default",
+  "channel": "mock_id",
   "text": "<https://github.com/Codertocat/Hello-World|[Codertocat/Hello-World]> CI Build Status notification: success",
   "attachments": [
     {
@@ -538,6 +544,8 @@ will notify #default
   ]
 }
 ===== file ../mock_payloads/status.success_test_main_branch.json =====
+looking up slack user by email mail@example.org
+{ "email": "mail@example.org" }
 will notify #all-push-events
 {
   "channel": "all-push-events",
@@ -557,9 +565,11 @@ will notify #all-push-events
   ]
 }
 ===== file ../mock_payloads/status.success_test_non_main_branch.json =====
-will notify #default
+looking up slack user by email mail@example.org
+{ "email": "mail@example.org" }
+will notify #mock_id
 {
-  "channel": "default",
+  "channel": "mock_id",
   "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2/builds/2|buildkite/pipeline2>: success",
   "attachments": [
     {

--- a/test/slack_payloads.expected
+++ b/test/slack_payloads.expected
@@ -497,9 +497,9 @@ will notify #longest-a1
 }
 ===== file ../mock_payloads/status.cancelled_test.json =====
 ===== file ../mock_payloads/status.failure_test.json =====
-will notify #id[mail@example.org]
+will notify #id[slack_mail@example.com]
 {
-  "channel": "id[mail@example.org]",
+  "channel": "id[slack_mail@example.com]",
   "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2/builds/2|buildkite/pipeline2>: failure",
   "attachments": [
     {
@@ -557,9 +557,9 @@ will notify #all-push-events
   ]
 }
 ===== file ../mock_payloads/status.success_test_non_main_branch.json =====
-will notify #id[mail@example.org]
+will notify #id[slack_mail@example.com]
 {
-  "channel": "id[mail@example.org]",
+  "channel": "id[slack_mail@example.com]",
   "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2/builds/2|buildkite/pipeline2>: success",
   "attachments": [
     {

--- a/test/slack_payloads.expected
+++ b/test/slack_payloads.expected
@@ -497,11 +497,9 @@ will notify #longest-a1
 }
 ===== file ../mock_payloads/status.cancelled_test.json =====
 ===== file ../mock_payloads/status.failure_test.json =====
-looking up slack user by email mail@example.org
-{ "email": "mail@example.org" }
-will notify #mock_id
+will notify #id[mail@example.org]
 {
-  "channel": "mock_id",
+  "channel": "id[mail@example.org]",
   "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2/builds/2|buildkite/pipeline2>: failure",
   "attachments": [
     {
@@ -520,15 +518,11 @@ will notify #mock_id
 ===== file ../mock_payloads/status.merge_develop.json =====
 ===== file ../mock_payloads/status.pending_test.json =====
 ===== file ../mock_payloads/status.state_hide_success_test.json =====
-looking up slack user by email mail@example.org
-{ "email": "mail@example.org" }
 ===== file ../mock_payloads/status.state_hide_success_test_disallowed_pipeline.json =====
 ===== file ../mock_payloads/status.success_public_repo_no_buildkite.json =====
-looking up slack user by email 21031067+Codertocat@users.noreply.github.com
-{ "email": "21031067+Codertocat@users.noreply.github.com" }
-will notify #mock_id
+will notify #id[21031067+Codertocat@users.noreply.github.com]
 {
-  "channel": "mock_id",
+  "channel": "id[21031067+Codertocat@users.noreply.github.com]",
   "text": "<https://github.com/Codertocat/Hello-World|[Codertocat/Hello-World]> CI Build Status notification: success",
   "attachments": [
     {
@@ -544,8 +538,6 @@ will notify #mock_id
   ]
 }
 ===== file ../mock_payloads/status.success_test_main_branch.json =====
-looking up slack user by email mail@example.org
-{ "email": "mail@example.org" }
 will notify #all-push-events
 {
   "channel": "all-push-events",
@@ -565,11 +557,9 @@ will notify #all-push-events
   ]
 }
 ===== file ../mock_payloads/status.success_test_non_main_branch.json =====
-looking up slack user by email mail@example.org
-{ "email": "mail@example.org" }
-will notify #mock_id
+will notify #id[mail@example.org]
 {
-  "channel": "mock_id",
+  "channel": "id[mail@example.org]",
   "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2/builds/2|buildkite/pipeline2>: success",
   "attachments": [
     {


### PR DESCRIPTION
This PR changes the channel routing logic for CI updates. The old behavior used to send ci updates to the default channel specified in the config. The new behavior now sends the ci update as a direct message to the author of the commit.

## How it works
The slack `post_message` api is able to send a direct message to a slack user by filling the `channel` field instead with the user_id. Since the Github commit author email and the slack profile email is the same, I have injected a new slack api call to get the user_id of a profile from a user's email address.

## Test
expect tests in [test/slack_payloads.expected](https://github.com/ahrefs/monorobot/compare/master...koonwen:ci_DMs?expand=1#diff-609587b97db0cf743c38c44ebc1c2934f832ff34233656fd49cddc44e675e86a) have been updated showing the slack notifications being sent to the author of the commit via the user_id

## References
https://github.com/ahrefs/monorobot/issues/81