### PR TITLE
CI status updates sent as direct message to author of commit

### DIFF
--- a/documentation/config_docs.md
+++ b/documentation/config_docs.md
@@ -163,7 +163,7 @@ The following takes place when a status notification is received.
    - `failure`: `allow`
    - `error`: `allow`
    - `success`: `allow_once`
-1. For those payloads allowed by step 1, if it isn't a main branch build notification, route to the default channel to reduce spam in topic channels. Otherwise, check the notification commit's files according to the prefix rules.
+1. For those payloads allowed by step 1, if it isn't a main branch build notification, query for a slack profile that matches the author of the commit and direct message them. If no profile is found, route to default channel to reduce spam in topic channels. Otherwise, check the notification commit's files according to the prefix rules.
 
 Internally, the bot keeps track of the status of the last allowed payload, for a given pipeline and branch. This information is used to evaluate the status rules (see below).
 

--- a/documentation/config_docs.md
+++ b/documentation/config_docs.md
@@ -163,7 +163,7 @@ The following takes place when a status notification is received.
    - `failure`: `allow`
    - `error`: `allow`
    - `success`: `allow_once`
-1. For those payloads allowed by step 1, if it isn't a main branch build notification, query for a slack profile that matches the author of the commit and direct message them. If no profile is found, route to default channel to reduce spam in topic channels. Otherwise, check the notification commit's files according to the prefix rules.
+1. For those payloads allowed by step 1, if it isn't a main branch build notification, route to the default channel to reduce spam in topic channels. Otherwise, check the notification commit's files according to the prefix rules. In addition, query for a slack profile that matches the author of the commit and direct message them.
 
 Internally, the bot keeps track of the status of the last allowed payload, for a given pipeline and branch. This information is used to evaluate the status rules (see below).
 
@@ -175,6 +175,7 @@ Internally, the bot keeps track of the status of the last allowed payload, for a
         "default",
         "buildkite/monorobot-test"
     ],
+    "enable_direct_message": true,
     "rules": [
         {
             "on": ["failure"],
@@ -196,6 +197,7 @@ Internally, the bot keeps track of the status of the last allowed payload, for a
 | value | description | default |
 |-|-|-|
 | `allowed_pipelines` | a list of pipeline names; if specified, payloads whose pipeline name is not in the list will be ignored immediately, without checking the **status rules** | all pipelines included in the status rule check |
+| `enable_direct_message` | control direct message sent to notify about build status | false |
 | `rules` | a list of **status rules** to determine whether to *allow* or *ignore* a payload for further processing | required field |
 
 ### Status Rules

--- a/lib/action.ml
+++ b/lib/action.ml
@@ -100,7 +100,7 @@ module Action (Github_api : Api.Github) (Slack_api : Api.Slack) = struct
     let rules = cfg.status_rules.rules in
     let action_on_match (branches : branch list) =
       let%lwt default =
-        match%lwt Slack_api.lookup_user ~ctx ~email:n.commit.commit.author.email with
+        match%lwt Slack_api.lookup_user ~ctx ~cfg ~email:n.commit.commit.author.email with
         (* To send a DM, channel parameter is set to the user id of the recipient *)
         | Ok res -> Lwt.return [ res.user.id ]
         | Error e ->

--- a/lib/action.ml
+++ b/lib/action.ml
@@ -99,30 +99,34 @@ module Action (Github_api : Api.Github) (Slack_api : Api.Slack) = struct
     let current_status = n.state in
     let rules = cfg.status_rules.rules in
     let action_on_match (branches : branch list) =
-      let%lwt default =
+      let%lwt direct_message =
         match%lwt Slack_api.lookup_user ~ctx ~cfg ~email:n.commit.commit.author.email with
         (* To send a DM, channel parameter is set to the user id of the recipient *)
         | Ok res -> Lwt.return [ res.user.id ]
         | Error e ->
           log#warn "couldn't match commit email to slack profile: %s" e;
-          Lwt.return (Option.to_list cfg.prefix_rules.default_channel)
+          Lwt.return []
       in
+      let default = Option.to_list cfg.prefix_rules.default_channel in
       let%lwt () = State.set_repo_pipeline_status ctx.state repo.url ~pipeline ~branches ~status:current_status in
-      match List.is_empty branches with
-      | true -> Lwt.return []
-      | false ->
-      match cfg.main_branch_name with
-      | None -> Lwt.return default
-      | Some main_branch_name ->
-      (* non-main branch build notifications go to default channel to reduce spam in topic channels *)
-      match List.exists branches ~f:(fun { name } -> String.equal name main_branch_name) with
-      | false -> Lwt.return default
-      | true ->
-        let sha = n.commit.sha in
-        ( match%lwt Github_api.get_api_commit ~ctx ~repo ~sha with
-        | Error e -> action_error e
-        | Ok commit -> Lwt.return @@ partition_commit cfg commit.files
-        )
+      let%lwt chans =
+        match List.is_empty branches with
+        | true -> Lwt.return []
+        | false ->
+        match cfg.main_branch_name with
+        | None -> Lwt.return default
+        | Some main_branch_name ->
+        (* non-main branch build notifications go to default channel to reduce spam in topic channels *)
+        match List.exists branches ~f:(fun { name } -> String.equal name main_branch_name) with
+        | false -> Lwt.return default
+        | true ->
+          let sha = n.commit.sha in
+          ( match%lwt Github_api.get_api_commit ~ctx ~repo ~sha with
+          | Error e -> action_error e
+          | Ok commit -> Lwt.return @@ partition_commit cfg commit.files
+          )
+      in
+      Lwt.return (direct_message @ chans)
     in
     if Context.is_pipeline_allowed ctx repo.url ~pipeline then begin
       let%lwt repo_state = State.find_or_add_repo ctx.state repo.url in

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -18,7 +18,7 @@ module type Github = sig
 end
 
 module type Slack = sig
-  val lookup_user : ctx:Context.t -> email:string -> lookup_user_res slack_response Lwt.t
+  val lookup_user : ctx:Context.t -> cfg:Config_t.config -> email:string -> lookup_user_res slack_response Lwt.t
   val send_notification : ctx:Context.t -> msg:post_message_req -> unit slack_response Lwt.t
 
   val send_chat_unfurl

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -19,7 +19,6 @@ end
 
 module type Slack = sig
   val lookup_user : ctx:Context.t -> email:string -> lookup_user_res slack_response Lwt.t
-
   val send_notification : ctx:Context.t -> msg:post_message_req -> unit slack_response Lwt.t
 
   val send_chat_unfurl

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -18,6 +18,8 @@ module type Github = sig
 end
 
 module type Slack = sig
+  val lookup_user : ctx:Context.t -> email:string -> lookup_user_res slack_response Lwt.t
+
   val send_notification : ctx:Context.t -> msg:post_message_req -> unit slack_response Lwt.t
 
   val send_chat_unfurl

--- a/lib/api_local.ml
+++ b/lib/api_local.ml
@@ -52,7 +52,7 @@ end
 
 (** The base implementation for local check payload debugging and mocking tests *)
 module Slack_base : Api.Slack = struct
-  let lookup_user ~ctx:_ ~email:_ = Lwt.return @@ Error "undefined for local setup"
+  let lookup_user ~ctx:_ ~cfg:_ ~email:_ = Lwt.return @@ Error "undefined for local setup"
   let send_notification ~ctx:_ ~msg:_ = Lwt.return @@ Error "undefined for local setup"
   let send_chat_unfurl ~ctx:_ ~channel:_ ~ts:_ ~unfurls:_ () = Lwt.return @@ Error "undefined for local setup"
   let send_auth_test ~ctx:_ () = Lwt.return @@ Error "undefined for local setup"
@@ -62,7 +62,8 @@ end
 module Slack : Api.Slack = struct
   include Slack_base
 
-  let lookup_user ~ctx:_ ~email =
+  let lookup_user ~ctx:_ ~(cfg : Config_t.config) ~email =
+    let email = List.Assoc.find cfg.user_mappings ~equal:String.equal email |> Option.value ~default:email in
     let mock_user =
       {
         Slack_t.id = sprintf "id[%s]" email;

--- a/lib/api_local.ml
+++ b/lib/api_local.ml
@@ -63,12 +63,14 @@ module Slack : Api.Slack = struct
   include Slack_base
 
   let lookup_user ~ctx:_ ~email =
-    let msg = {Slack_t.email = email} in
-    let json = msg |> Slack_j.string_of_lookup_user_req  |> Yojson.Basic.from_string |> Yojson.Basic.pretty_to_string in
-    Stdio.printf "looking up slack user by email %s\n" email;
-    Stdio.printf "%s\n" json;
-    let mock_user = {Slack_t.id = "mock_id"; name="mock_name"; real_name="mock_real_name"} in
-    let mock_response = {Slack_t.user = mock_user} in
+    let mock_user =
+      {
+        Slack_t.id = sprintf "id[%s]" email;
+        name = sprintf "name[%s]" email;
+        real_name = sprintf "real_name[%s]" email;
+      }
+    in
+    let mock_response = { Slack_t.user = mock_user } in
     Lwt.return @@ Ok mock_response
 
   let send_notification ~ctx:_ ~msg =

--- a/lib/api_remote.ml
+++ b/lib/api_remote.ml
@@ -118,21 +118,11 @@ module Slack : Api.Slack = struct
     ignore (Slack_j.read_ok_res s l)
 
   (** [lookup_user ctx email] queries slack for a user profile with [email] *)
-  let lookup_user ~(ctx: Context.t) ~email =
-    log#info "looking up %s\n" email;
-    let build_error e = fmt_error "%s\nfailed to lookup Slack user" e in
-    let secrets = Context.get_secrets_exn ctx in
-    match secrets.slack_access_token with
-    | None -> Lwt.return @@ build_error @@ sprintf "no token configured to lookup user email %s" email
-    | Some access_token ->
-      let headers = [ bearer_token_header access_token ] in
-      let data = {Slack_t.email = email} |> Slack_j.string_of_lookup_user_req in
-      let body = `Raw ("application/json", data) in
-      let url ="https://slack.com/api/users.lookupByEmail" in
-      log#info "data: %s" data;
-      match%lwt slack_api_request ~body ~headers `GET url Slack_j.read_lookup_user_res with
-      | Ok res -> Lwt.return @@ Ok res
-      | Error e -> Lwt.return @@ build_error e
+  let lookup_user ~(ctx : Context.t) ~email =
+    let data = Slack_j.string_of_lookup_user_req { Slack_t.email } in
+    request_token_auth ~name:"lookup user by email"
+      ~body:(`Raw ("application/json", data))
+      ~ctx `GET "users.lookupByEmail" Slack_j.read_lookup_user_res
 
   (** [send_notification ctx msg] notifies [msg.channel] with the payload [msg];
       uses web API with access token if available, or with webhook otherwise *)

--- a/lib/api_remote.ml
+++ b/lib/api_remote.ml
@@ -117,8 +117,10 @@ module Slack : Api.Slack = struct
     (* must read whole response to update lexer state *)
     ignore (Slack_j.read_ok_res s l)
 
-  (** [lookup_user ctx email] queries slack for a user profile with [email] *)
-  let lookup_user ~(ctx : Context.t) ~email =
+  (** [lookup_user cfg email] queries slack for a user profile with [email] *)
+  let lookup_user ~(ctx : Context.t) ~(cfg : Config_t.config) ~email =
+    (* Check if config holds the Github to Slack email mapping  *)
+    let email = List.Assoc.find cfg.user_mappings ~equal:String.equal email |> Option.value ~default:email in
     let data = Slack_j.string_of_lookup_user_req { Slack_t.email } in
     request_token_auth ~name:"lookup user by email"
       ~body:(`Raw ("application/json", data))

--- a/lib/config.atd
+++ b/lib/config.atd
@@ -37,6 +37,7 @@ type config = {
   ~project_owners <ocaml default="{rules = []}"> : project_owners;
   ~ignored_users <ocaml default="[]">: string list; (* list of ignored users *)
   ?main_branch_name : string nullable; (* the name of the main branch; used to filter out notifications about merges of main branch into other branches *)
+  ~user_mappings <ocaml default="[]">: (string * string) list <json repr="object"> (* list of github to slack profile mappings *)
 }
 
 (* This specifies the Slack webhook to query to post to the channel with the given name *)

--- a/lib/config.atd
+++ b/lib/config.atd
@@ -6,6 +6,7 @@ type project_owners_rule <ocaml from="Rule"> = abstract
 (* This type of rule is used for CI build notifications. *)
 type status_rules = {
   ?allowed_pipelines : string list nullable; (* keep only status events with a title matching this list *)
+  ?enable_direct_message: bool nullable;
   rules: status_rule list;
 }
 
@@ -33,7 +34,7 @@ type project_owners = {
 type config = {
   prefix_rules : prefix_rules;
   label_rules : label_rules;
-  ~status_rules <ocaml default="{allowed_pipelines = Some []; rules = []}"> : status_rules;
+  ~status_rules <ocaml default="{allowed_pipelines = Some []; enable_direct_message = Some false; rules = []}"> : status_rules;
   ~project_owners <ocaml default="{rules = []}"> : project_owners;
   ~ignored_users <ocaml default="[]">: string list; (* list of ignored users *)
   ?main_branch_name : string nullable; (* the name of the main branch; used to filter out notifications about merges of main branch into other branches *)

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -2,6 +2,8 @@ open Base
 open Common
 open Devkit
 
+let log = Log.from "context"
+
 exception Context_error of string
 
 let context_error fmt = Printf.ksprintf (fun msg -> raise (Context_error msg)) fmt
@@ -69,7 +71,10 @@ let is_pipeline_allowed ctx repo_url ~pipeline =
   | Some allowed_pipelines when not @@ List.exists allowed_pipelines ~f:(String.equal pipeline) -> false
   | _ -> true
 
-let log = Log.from "context"
+let is_status_direct_message_enabled ctx repo_url =
+  match find_repo_config ctx repo_url with
+  | None -> true
+  | Some config -> Option.value config.status_rules.enable_direct_message ~default:false
 
 let refresh_secrets ctx =
   let path = ctx.secrets_filepath in

--- a/lib/slack.atd
+++ b/lib/slack.atd
@@ -67,6 +67,20 @@ type post_message_res = {
   channel: string;
 }
 
+type lookup_user_req = {
+  email: string;
+}
+
+type lookup_user_res = {
+  user: user;
+}
+
+type user = {
+  id: string;
+  name: string;
+  real_name: string;
+}
+
 type link_shared_link = {
   domain: string;
   url: string;

--- a/test/monorobot.json
+++ b/test/monorobot.json
@@ -95,5 +95,8 @@
                 "channel": "frontend-bot"
             }
         ]
+    },
+    "user_mappings": {
+        "mail@example.org": "slack_mail@example.com"
     }
 }

--- a/test/slack_payloads.expected
+++ b/test/slack_payloads.expected
@@ -497,9 +497,11 @@ will notify #longest-a1
 }
 ===== file ../mock_payloads/status.cancelled_test.json =====
 ===== file ../mock_payloads/status.failure_test.json =====
-will notify #default
+looking up slack user by email mail@example.org
+{ "email": "mail@example.org" }
+will notify #mock_id
 {
-  "channel": "default",
+  "channel": "mock_id",
   "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2/builds/2|buildkite/pipeline2>: failure",
   "attachments": [
     {
@@ -518,11 +520,15 @@ will notify #default
 ===== file ../mock_payloads/status.merge_develop.json =====
 ===== file ../mock_payloads/status.pending_test.json =====
 ===== file ../mock_payloads/status.state_hide_success_test.json =====
+looking up slack user by email mail@example.org
+{ "email": "mail@example.org" }
 ===== file ../mock_payloads/status.state_hide_success_test_disallowed_pipeline.json =====
 ===== file ../mock_payloads/status.success_public_repo_no_buildkite.json =====
-will notify #default
+looking up slack user by email 21031067+Codertocat@users.noreply.github.com
+{ "email": "21031067+Codertocat@users.noreply.github.com" }
+will notify #mock_id
 {
-  "channel": "default",
+  "channel": "mock_id",
   "text": "<https://github.com/Codertocat/Hello-World|[Codertocat/Hello-World]> CI Build Status notification: success",
   "attachments": [
     {
@@ -538,6 +544,8 @@ will notify #default
   ]
 }
 ===== file ../mock_payloads/status.success_test_main_branch.json =====
+looking up slack user by email mail@example.org
+{ "email": "mail@example.org" }
 will notify #all-push-events
 {
   "channel": "all-push-events",
@@ -557,9 +565,11 @@ will notify #all-push-events
   ]
 }
 ===== file ../mock_payloads/status.success_test_non_main_branch.json =====
-will notify #default
+looking up slack user by email mail@example.org
+{ "email": "mail@example.org" }
+will notify #mock_id
 {
-  "channel": "default",
+  "channel": "mock_id",
   "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2/builds/2|buildkite/pipeline2>: success",
   "attachments": [
     {

--- a/test/slack_payloads.expected
+++ b/test/slack_payloads.expected
@@ -497,9 +497,9 @@ will notify #longest-a1
 }
 ===== file ../mock_payloads/status.cancelled_test.json =====
 ===== file ../mock_payloads/status.failure_test.json =====
-will notify #id[mail@example.org]
+will notify #id[slack_mail@example.com]
 {
-  "channel": "id[mail@example.org]",
+  "channel": "id[slack_mail@example.com]",
   "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2/builds/2|buildkite/pipeline2>: failure",
   "attachments": [
     {
@@ -557,9 +557,9 @@ will notify #all-push-events
   ]
 }
 ===== file ../mock_payloads/status.success_test_non_main_branch.json =====
-will notify #id[mail@example.org]
+will notify #id[slack_mail@example.com]
 {
-  "channel": "id[mail@example.org]",
+  "channel": "id[slack_mail@example.com]",
   "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2/builds/2|buildkite/pipeline2>: success",
   "attachments": [
     {

--- a/test/slack_payloads.expected
+++ b/test/slack_payloads.expected
@@ -515,9 +515,45 @@ will notify #id[slack_mail@example.com]
     }
   ]
 }
+will notify #default
+{
+  "channel": "default",
+  "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2/builds/2|buildkite/pipeline2>: failure",
+  "attachments": [
+    {
+      "fallback": null,
+      "mrkdwn_in": [ "fields", "text" ],
+      "color": "danger",
+      "text": "*Description*: Build #2 failed (20 seconds).",
+      "fields": [
+        {
+          "value": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/0d95302addd66c1816bce1b1d495ed1c93ccd478|0d95302a>` Update README.md - Khady\n*Branch*: master"
+        }
+      ]
+    }
+  ]
+}
 ===== file ../mock_payloads/status.merge_develop.json =====
 ===== file ../mock_payloads/status.pending_test.json =====
 ===== file ../mock_payloads/status.state_hide_success_test.json =====
+will notify #id[slack_mail@example.com]
+{
+  "channel": "id[slack_mail@example.com]",
+  "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2/builds/2|buildkite/pipeline2>: success",
+  "attachments": [
+    {
+      "fallback": null,
+      "mrkdwn_in": [ "fields", "text" ],
+      "color": "good",
+      "text": "*Description*: Build #2 passed (5 minutes, 19 seconds).",
+      "fields": [
+        {
+          "value": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/0d95302addd66c1816bce1b1d495ed1c93ccd478|0d95302a>` Update README.md - Khady\n*Branch*: master"
+        }
+      ]
+    }
+  ]
+}
 ===== file ../mock_payloads/status.state_hide_success_test_disallowed_pipeline.json =====
 ===== file ../mock_payloads/status.success_public_repo_no_buildkite.json =====
 will notify #id[21031067+Codertocat@users.noreply.github.com]
@@ -537,7 +573,42 @@ will notify #id[21031067+Codertocat@users.noreply.github.com]
     }
   ]
 }
+will notify #default
+{
+  "channel": "default",
+  "text": "<https://github.com/Codertocat/Hello-World|[Codertocat/Hello-World]> CI Build Status notification: success",
+  "attachments": [
+    {
+      "fallback": null,
+      "mrkdwn_in": [ "fields", "text" ],
+      "color": "good",
+      "fields": [
+        {
+          "value": "*Commit*: `<https://github.com/Codertocat/Hello-World/commit/6113728f27ae82c7b1a177c8d03f9e96e0adf246|6113728f>` Initial commit - Codertocat\n*Branches*: master, changes, gh-pages"
+        }
+      ]
+    }
+  ]
+}
 ===== file ../mock_payloads/status.success_test_main_branch.json =====
+will notify #id[slack_mail@example.com]
+{
+  "channel": "id[slack_mail@example.com]",
+  "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2/builds/2|buildkite/pipeline2>: success",
+  "attachments": [
+    {
+      "fallback": null,
+      "mrkdwn_in": [ "fields", "text" ],
+      "color": "good",
+      "text": "*Description*: Build #2 passed (5 minutes, 19 seconds).",
+      "fields": [
+        {
+          "value": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/0d95302addd66c1816bce1b1d495ed1c93ccd478|0d95302a>` Update README.md - Khady\n*Branch*: develop"
+        }
+      ]
+    }
+  ]
+}
 will notify #all-push-events
 {
   "channel": "all-push-events",
@@ -560,6 +631,24 @@ will notify #all-push-events
 will notify #id[slack_mail@example.com]
 {
   "channel": "id[slack_mail@example.com]",
+  "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2/builds/2|buildkite/pipeline2>: success",
+  "attachments": [
+    {
+      "fallback": null,
+      "mrkdwn_in": [ "fields", "text" ],
+      "color": "good",
+      "text": "*Description*: Build #2 passed (5 minutes, 19 seconds).",
+      "fields": [
+        {
+          "value": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/0d95302addd66c1816bce1b1d495ed1c93ccd478|0d95302a>` Update README.md - Khady\n*Branch*: master"
+        }
+      ]
+    }
+  ]
+}
+will notify #default
+{
+  "channel": "default",
   "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2/builds/2|buildkite/pipeline2>: success",
   "attachments": [
     {

--- a/test/slack_payloads.expected
+++ b/test/slack_payloads.expected
@@ -497,11 +497,9 @@ will notify #longest-a1
 }
 ===== file ../mock_payloads/status.cancelled_test.json =====
 ===== file ../mock_payloads/status.failure_test.json =====
-looking up slack user by email mail@example.org
-{ "email": "mail@example.org" }
-will notify #mock_id
+will notify #id[mail@example.org]
 {
-  "channel": "mock_id",
+  "channel": "id[mail@example.org]",
   "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2/builds/2|buildkite/pipeline2>: failure",
   "attachments": [
     {
@@ -520,15 +518,11 @@ will notify #mock_id
 ===== file ../mock_payloads/status.merge_develop.json =====
 ===== file ../mock_payloads/status.pending_test.json =====
 ===== file ../mock_payloads/status.state_hide_success_test.json =====
-looking up slack user by email mail@example.org
-{ "email": "mail@example.org" }
 ===== file ../mock_payloads/status.state_hide_success_test_disallowed_pipeline.json =====
 ===== file ../mock_payloads/status.success_public_repo_no_buildkite.json =====
-looking up slack user by email 21031067+Codertocat@users.noreply.github.com
-{ "email": "21031067+Codertocat@users.noreply.github.com" }
-will notify #mock_id
+will notify #id[21031067+Codertocat@users.noreply.github.com]
 {
-  "channel": "mock_id",
+  "channel": "id[21031067+Codertocat@users.noreply.github.com]",
   "text": "<https://github.com/Codertocat/Hello-World|[Codertocat/Hello-World]> CI Build Status notification: success",
   "attachments": [
     {
@@ -544,8 +538,6 @@ will notify #mock_id
   ]
 }
 ===== file ../mock_payloads/status.success_test_main_branch.json =====
-looking up slack user by email mail@example.org
-{ "email": "mail@example.org" }
 will notify #all-push-events
 {
   "channel": "all-push-events",
@@ -565,11 +557,9 @@ will notify #all-push-events
   ]
 }
 ===== file ../mock_payloads/status.success_test_non_main_branch.json =====
-looking up slack user by email mail@example.org
-{ "email": "mail@example.org" }
-will notify #mock_id
+will notify #id[mail@example.org]
 {
-  "channel": "mock_id",
+  "channel": "id[mail@example.org]",
   "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2/builds/2|buildkite/pipeline2>: success",
   "attachments": [
     {


### PR DESCRIPTION
supersede #134

This PR changes the channel routing logic for CI updates. The old behavior used to send ci updates to the default channel specified in the config. In addition, notifications are now also sent as direct messages.

## References
https://github.com/ahrefs/monorobot/issues/81
https://github.com/ahrefs/monorobot/pull/134