### PR TITLE
make build number in description a link when using buildkite

### DIFF
--- a/lib/slack.ml
+++ b/lib/slack.ml
@@ -246,7 +246,21 @@ let generate_status_notification (cfg : Config_t.config) (notification : status_
   let description_info =
     match description with
     | None -> None
-    | Some s -> Some (sprintf "*Description*: %s." s)
+    | Some s ->
+      let text =
+        match target_url with
+        | None -> s
+        | Some target_url ->
+          (* Specific to buildkite *)
+          let re = Re2.create_exn {|^Build #(\d+)(.*)|} in
+          ( match Re2.find_submatches_exn re s with
+          | [| Some _; Some build_nr; Some rest |] ->
+            (* We use a zero-with space \u{200B} to prevent slack from interpreting #XXXXXX as a color *)
+            sprintf "Build <%s|#\u{200B}%s>%s" target_url build_nr rest
+          | _ -> s
+          )
+      in
+      Some (sprintf "*Description*: %s." text)
   in
   let commit_info =
     [ sprintf "*Commit*: `<%s|%s>` %s - %s" html_url (git_short_sha_hash sha) (first_line message) author.login ]

--- a/test/slack_payloads.expected
+++ b/test/slack_payloads.expected
@@ -440,7 +440,7 @@ will notify #id[slack_mail@example.com]
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Description*: Build #2 failed (20 seconds).",
+      "text": "*Description*: Build <https://buildkite.com/org/pipeline2/builds/2|#​2> failed (20 seconds).",
       "fields": [
         {
           "value": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/0d95302addd66c1816bce1b1d495ed1c93ccd478|0d95302a>` Update README.md - Khady\n*Branch*: master"
@@ -459,7 +459,7 @@ will notify #default
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Description*: Build #2 failed (20 seconds).",
+      "text": "*Description*: Build <https://buildkite.com/org/pipeline2/builds/2|#​2> failed (20 seconds).",
       "fields": [
         {
           "value": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/0d95302addd66c1816bce1b1d495ed1c93ccd478|0d95302a>` Update README.md - Khady\n*Branch*: master"
@@ -502,7 +502,7 @@ will notify #all-push-events
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "good",
-      "text": "*Description*: Build #2 passed (5 minutes, 19 seconds).",
+      "text": "*Description*: Build <https://buildkite.com/org/pipeline2/builds/2|#​2> passed (5 minutes, 19 seconds).",
       "fields": [
         {
           "value": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/0d95302addd66c1816bce1b1d495ed1c93ccd478|0d95302a>` Update README.md - Khady\n*Branch*: develop"
@@ -522,7 +522,7 @@ will notify #default
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "good",
-      "text": "*Description*: Build #2 passed (5 minutes, 19 seconds).",
+      "text": "*Description*: Build <https://buildkite.com/org/pipeline2/builds/2|#​2> passed (5 minutes, 19 seconds).",
       "fields": [
         {
           "value": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/0d95302addd66c1816bce1b1d495ed1c93ccd478|0d95302a>` Update README.md - Khady\n*Branch*: master"


### PR DESCRIPTION
## Description of the task

This PR tries to parse the description text when using Buildkite to extract the build number and make it a link. It also adds a zero-width space between the `#` and the build number to prevent it from being interpreted as a colour.

![image](https://github.com/ahrefs/monorobot/assets/5595092/0450b643-00b8-4ad1-a153-831e8f35aaec)


## How to test

See changes in tests

## References
* Slack: https://ahrefs.slack.com/archives/CKZANG2TE/p1709589315074549

