### PR TITLE
fix link to pipeline when using buildkite

### DIFF
--- a/lib/slack.ml
+++ b/lib/slack.ml
@@ -239,7 +239,7 @@ let generate_status_notification (cfg : Config_t.config) (notification : status_
       let text =
         match target_url with
         | None -> s
-        | Some target_url when not is_buildkite -> sprintf "*Description*: %s." target_url
+        | Some _ when not is_buildkite -> s
         | Some target_url ->
         (* Specific to buildkite *)
         match Re2.find_submatches_exn buildkite_description_re s with

--- a/lib/slack.ml
+++ b/lib/slack.ml
@@ -290,13 +290,7 @@ let generate_status_notification (cfg : Config_t.config) (notification : status_
       else (
         (* Keep only the portion of the url before /builds/... *)
         let pipeline_url =
-          let rec loop = function
-            | [] -> None
-            | "builds" :: l -> Some (List.rev l |> String.concat "/")
-            | _ :: l -> loop l
-          in
-          let url_parts = target_url |> String.split_on_char '/' |> List.rev in
-          loop url_parts
+          try Some (ExtLib.String.split target_url "/builds" |> fst) with ExtLib.Invalid_string -> None
         in
         match pipeline_url with
         | None -> default_summary

--- a/lib/slack.ml
+++ b/lib/slack.ml
@@ -290,7 +290,10 @@ let generate_status_notification (cfg : Config_t.config) (notification : status_
       else (
         (* Keep only the portion of the url before /builds/... *)
         let pipeline_url =
-          try Some (ExtLib.String.split target_url "/builds" |> fst) with ExtLib.Invalid_string -> None
+          match String.split_on_char '/' target_url with
+          | "https:" :: "" :: "buildkite.com" :: "org" :: pipeline :: "builds" :: _ ->
+            Some (Printf.sprintf "https://buildkite.com/org/%s" pipeline)
+          | _ -> None
         in
         match pipeline_url with
         | None -> default_summary

--- a/lib/slack.ml
+++ b/lib/slack.ml
@@ -229,6 +229,7 @@ let generate_status_notification (cfg : Config_t.config) (notification : status_
   let { commit; state; description; target_url; context; repository; _ } = notification in
   let ({ commit : inner_commit; sha; author; html_url; _ } : status_commit) = commit in
   let ({ message; _ } : inner_commit) = commit in
+  let is_buildkite = String.is_prefix context ~prefix:"buildkite" in
   let color_info =
     match state with
     | Success -> "good"
@@ -241,6 +242,7 @@ let generate_status_notification (cfg : Config_t.config) (notification : status_
       let text =
         match target_url with
         | None -> s
+        | Some target_url when not is_buildkite -> sprintf "*Description*: %s." target_url
         | Some target_url ->
         (* Specific to buildkite *)
         match Re2.find_submatches_exn buildkite_description_re s with
@@ -285,7 +287,6 @@ let generate_status_notification (cfg : Config_t.config) (notification : status_
     match target_url with
     | None -> sprintf "<%s|[%s]> CI Build Status notification: %s" repository.url repository.full_name state_info
     | Some target_url ->
-      let is_buildkite = String.is_prefix context ~prefix:"buildkite" in
       let default_summary =
         sprintf "<%s|[%s]> CI Build Status notification for <%s|%s>: %s" repository.url repository.full_name target_url
           context state_info

--- a/test/slack_payloads.expected
+++ b/test/slack_payloads.expected
@@ -434,7 +434,7 @@ will notify #longest-a1
 will notify #id[slack_mail@example.com]
 {
   "channel": "id[slack_mail@example.com]",
-  "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2/builds/2|buildkite/pipeline2>: failure",
+  "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2|buildkite/pipeline2>: failure",
   "attachments": [
     {
       "fallback": null,
@@ -453,7 +453,7 @@ will notify #id[slack_mail@example.com]
 will notify #default
 {
   "channel": "default",
-  "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2/builds/2|buildkite/pipeline2>: failure",
+  "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2|buildkite/pipeline2>: failure",
   "attachments": [
     {
       "fallback": null,
@@ -496,7 +496,7 @@ will notify #default
 will notify #all-push-events
 {
   "channel": "all-push-events",
-  "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2/builds/2|buildkite/pipeline2>: success",
+  "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2|buildkite/pipeline2>: success",
   "attachments": [
     {
       "fallback": null,
@@ -516,7 +516,7 @@ will notify #all-push-events
 will notify #default
 {
   "channel": "default",
-  "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2/builds/2|buildkite/pipeline2>: success",
+  "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2|buildkite/pipeline2>: success",
   "attachments": [
     {
       "fallback": null,

--- a/test/slack_payloads.expected
+++ b/test/slack_payloads.expected
@@ -434,7 +434,7 @@ will notify #longest-a1
 will notify #id[slack_mail@example.com]
 {
   "channel": "id[slack_mail@example.com]",
-  "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2|buildkite/pipeline2>: failure",
+  "text": "<https://buildkite.com/org/pipeline2|[buildkite/pipeline2]>: Build failed for \"Update README.md\"",
   "attachments": [
     {
       "fallback": null,
@@ -453,7 +453,7 @@ will notify #id[slack_mail@example.com]
 will notify #default
 {
   "channel": "default",
-  "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2|buildkite/pipeline2>: failure",
+  "text": "<https://buildkite.com/org/pipeline2|[buildkite/pipeline2]>: Build failed for \"Update README.md\"",
   "attachments": [
     {
       "fallback": null,
@@ -477,7 +477,7 @@ will notify #default
 will notify #default
 {
   "channel": "default",
-  "text": "<https://github.com/Codertocat/Hello-World|[Codertocat/Hello-World]> CI Build Status notification: success",
+  "text": "<https://github.com/Codertocat/Hello-World|[Codertocat/Hello-World]>: Build succeeded for \"Initial commit\"",
   "attachments": [
     {
       "fallback": null,
@@ -496,7 +496,7 @@ will notify #default
 will notify #all-push-events
 {
   "channel": "all-push-events",
-  "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2|buildkite/pipeline2>: success",
+  "text": "<https://buildkite.com/org/pipeline2|[buildkite/pipeline2]>: Build succeeded for \"Update README.md\"",
   "attachments": [
     {
       "fallback": null,
@@ -516,7 +516,7 @@ will notify #all-push-events
 will notify #default
 {
   "channel": "default",
-  "text": "<https://github.com/ahrefs/monorepo|[ahrefs/monorepo]> CI Build Status notification for <https://buildkite.com/org/pipeline2|buildkite/pipeline2>: success",
+  "text": "<https://buildkite.com/org/pipeline2|[buildkite/pipeline2]>: Build succeeded for \"Update README.md\"",
   "attachments": [
     {
       "fallback": null,

--- a/test/slack_payloads.expected
+++ b/test/slack_payloads.expected
@@ -477,7 +477,7 @@ will notify #default
 will notify #default
 {
   "channel": "default",
-  "text": "<https://github.com/Codertocat/Hello-World|[Codertocat/Hello-World]>: Build succeeded for \"Initial commit\"",
+  "text": "<https://github.com/Codertocat/Hello-World|[Codertocat/Hello-World]> CI Build Status notification: succeeded",
   "attachments": [
     {
       "fallback": null,


### PR DESCRIPTION
## Description of the task

The pipeline e.g `buildkite/pipeline2` currently links to the actual build instead of the pipeline itself as one would expect.

This is what this PR tries to fix (only when using buildkite). We don't have the info about the pipeline's URL, so it tries to compute it based on the `context` and `target_url`.

## How to test

See changes in tests

## References

- Slack discussion: https://ahrefs.slack.com/archives/CKZANG2TE/p1709589315074549
