### PR TITLE
Replace GitHub handle with Slack handle instead of keeping both

### DIFF
--- a/lib/slack.ml
+++ b/lib/slack.ml
@@ -46,14 +46,14 @@ let markdown_text_attachment ~footer markdown_body =
 let make_message ?username ?text ?attachments ?blocks ~channel () =
   { channel; text; attachments; blocks; username; unfurl_links = Some false; unfurl_media = None }
 
-let github_handle_regex = Re2.create_exn {|(^|\s)@([\w][\w-]{1,})|} (* Match GH handles in messages *)
+let github_handle_regex = Re2.create_exn {|\B@([[:alnum:]][[:alnum:]-]{1,38})\b|}
+(* Match GH handles in messages - a GitHub handle has at most 39 chars and no underscore *)
 
 let add_slack_mentions_to_body slack_match_func body =
   let replace_match m =
     let gh_handle = Re2.Match.get_exn ~sub:(`Index 0) m in
-    let space = Re2.Match.get_exn ~sub:(`Index 1) m in
-    let gh_handle_without_at = Re2.Match.get_exn ~sub:(`Index 2) m in
-    Option.map_default (sprintf "%s<@%s>" space) gh_handle (slack_match_func gh_handle_without_at)
+    let gh_handle_without_at = Re2.Match.get_exn ~sub:(`Index 1) m in
+    Option.map_default (sprintf "<@%s>") gh_handle (slack_match_func gh_handle_without_at)
   in
   Re2.replace_exn github_handle_regex body ~f:replace_match
 

--- a/lib/slack.ml
+++ b/lib/slack.ml
@@ -46,14 +46,14 @@ let markdown_text_attachment ~footer markdown_body =
 let make_message ?username ?text ?attachments ?blocks ~channel () =
   { channel; text; attachments; blocks; username; unfurl_links = Some false; unfurl_media = None }
 
-let format_slack_mention = Option.map_default (sprintf " (<@%s>)") ""
-let github_handle_regex = Re2.create_exn {|(?:^|\s)@([\w][\w-]{1,})|} (* Match GH handles in messages *)
+let github_handle_regex = Re2.create_exn {|(^|\s)@([\w][\w-]{1,})|} (* Match GH handles in messages *)
 
 let add_slack_mentions_to_body slack_match_func body =
   let replace_match m =
     let gh_handle = Re2.Match.get_exn ~sub:(`Index 0) m in
-    let gh_handle_without_at = Re2.Match.get_exn ~sub:(`Index 1) m in
-    sprintf "%s%s" gh_handle (format_slack_mention (slack_match_func gh_handle_without_at))
+    let space = Re2.Match.get_exn ~sub:(`Index 1) m in
+    let gh_handle_without_at = Re2.Match.get_exn ~sub:(`Index 2) m in
+    Option.map_default (sprintf "%s<@%s>" space) gh_handle (slack_match_func gh_handle_without_at)
   in
   Re2.replace_exn github_handle_regex body ~f:replace_match
 

--- a/test/slack_payloads.expected
+++ b/test/slack_payloads.expected
@@ -8,7 +8,7 @@ will notify #all-push-events
       "fallback": null,
       "mrkdwn_in": [ "text" ],
       "color": "#ccc",
-      "text": "test commit comment, should mention slack id for @NotAPerson (<@slack_id_2>)"
+      "text": "test commit comment, should mention slack id for <@slack_id_2>"
     }
   ],
   "unfurl_links": false
@@ -191,7 +191,7 @@ will notify #default
       "fallback": null,
       "mrkdwn_in": [ "text" ],
       "color": "#ccc",
-      "text": "@phongulus (<@U06PUSUR2Q1>) test comment"
+      "text": "<@U06PUSUR2Q1> test comment"
     }
   ],
   "unfurl_links": false
@@ -260,7 +260,7 @@ will notify #default
       "fallback": null,
       "mrkdwn_in": [ "text" ],
       "color": "#ccc",
-      "text": "Pls do something about it @phongulus (<@U06PUSUR2Q1>) @phong-le (<@some_slack_id>) @NotAPerson (<@slack_id_2>)"
+      "text": "Pls do something about it <@U06PUSUR2Q1> <@some_slack_id> <@slack_id_2>"
     }
   ],
   "unfurl_links": false
@@ -340,7 +340,7 @@ will notify #default
       "fallback": null,
       "mrkdwn_in": [ "text" ],
       "color": "#ccc",
-      "text": "test pull request, mention @phongulus (<@U06PUSUR2Q1>)"
+      "text": "test pull request, mention <@U06PUSUR2Q1>"
     }
   ],
   "unfurl_links": false


### PR DESCRIPTION
## Description of the task

Minor change to replace GitHub handle with Slack handle in PR, issue and commit comments, as it's a bit verbose to keep both as done in https://github.com/ahrefs/monorobot/pull/143.

## How to test

```
make test
```