### PR TITLE
config: allow config filename per repo

### DIFF
--- a/lib/action.ml
+++ b/lib/action.ml
@@ -286,7 +286,7 @@ module Action (Github_api : Api.Github) (Slack_api : Api.Slack) = struct
     | Github.Push commit_pushed_notification ->
       let commits = commit_pushed_notification.commits in
       let modified_files = List.concat_map Github.modified_files_of_commit commits in
-      let config_was_modified = List.exists (String.equal ctx.config_filename) modified_files in
+      let config_was_modified = List.exists (String.equal (Context.get_config_filename ctx repo.url)) modified_files in
       if config_was_modified then fetch_config ~ctx ~repo else Lwt.return @@ Ok ()
     | _ -> Lwt.return @@ Ok ()
 

--- a/lib/api_local.ml
+++ b/lib/api_local.ml
@@ -29,8 +29,8 @@ let get_repo_member_cache ~(repo : Github_t.repository) ~kind ~ref_ ~of_string =
   with_cache_file url of_string
 
 module Github : Api.Github = struct
-  let get_config ~(ctx : Context.t) ~repo:_ =
-    let url = Filename.concat cwd ctx.config_filename in
+  let get_config ~(ctx : Context.t) ~(repo : Github_t.repository) =
+    let url = Filename.concat cwd (Context.get_config_filename ctx repo.url) in
     with_cache_file url Config_j.config_of_string
 
   let get_api_commit ~ctx:_ ~repo ~sha =

--- a/lib/api_remote.ml
+++ b/lib/api_remote.ml
@@ -29,7 +29,7 @@ module Github : Api.Github = struct
 
   let get_config ~(ctx : Context.t) ~repo =
     let secrets = Context.get_secrets_exn ctx in
-    let url = contents_url ~repo ~path:ctx.config_filename in
+    let url = contents_url ~repo ~path:(Context.get_config_filename ctx repo.url) in
     let token = Context.gh_token_of_secrets secrets repo.url in
     let headers = build_headers ?token () in
     match%lwt http_request ~headers `GET url with

--- a/lib/config.atd
+++ b/lib/config.atd
@@ -53,6 +53,8 @@ type repo_config = {
   ?gh_token : string nullable;
   (* GitHub webhook secret token to secure the webhook *)
   ?gh_hook_secret : string nullable;
+  (* override the default config filename for one repository *)
+  ?config_filename : string nullable;
 }
 
 (* This is the structure of the secrets file which stores sensitive information, and

--- a/lib/context.ml
+++ b/lib/context.ml
@@ -34,6 +34,14 @@ let get_secrets_exn ctx =
   | None -> context_error "secrets is uninitialized"
   | Some secrets -> secrets
 
+let get_config_filename ctx repo_url =
+  match get_secrets_exn ctx with
+  | exception Context_error _ -> ctx.config_filename
+  | secrets ->
+  match List.find_opt (fun r -> String.equal r.Config_t.url repo_url) secrets.repos with
+  | None | Some { config_filename = None; _ } -> ctx.config_filename
+  | Some { config_filename = Some f; _ } -> f
+
 let find_repo_config ctx repo_url = Stringtbl.find_opt ctx.config repo_url
 
 let find_repo_config_exn ctx repo_url =

--- a/test/test.ml
+++ b/test/test.ml
@@ -35,7 +35,9 @@ let process_gh_payload ~(secrets : Config_t.secrets) ~config (kind, path, state_
   let make_test_context event =
     let repo = Github.repo_of_notification @@ Github.parse_exn headers event in
     (* overwrite repo url in secrets with that of notification for this test case *)
-    let secrets = { secrets with repos = [ { url = repo.url; gh_token = None; gh_hook_secret = None } ] } in
+    let secrets =
+      { secrets with repos = [ { url = repo.url; gh_token = None; gh_hook_secret = None; config_filename = None } ] }
+    in
     let ctx = Context.make () in
     ctx.secrets <- Some secrets;
     let (_ : State_t.repo_state) = State.find_or_add_repo ctx.state repo.url in


### PR DESCRIPTION
Currently the config filename is set globally for all the repository. It's not really convenient because it doesn't allow any exception, and if one wants to change the filename it has to be done for all the repositories.

The existing code is a bit disorganised too. For example the default config name exists in two places with different values:
https://github.com/ahrefs/monorobot/blob/d52a846d9bb3263fc6bc645051ccbf2b69a6767e/src/monorobot.ml#L87
https://github.com/ahrefs/monorobot/blob/d52a846d9bb3263fc6bc645051ccbf2b69a6767e/lib/context.ml#L19

This PR adds yet another place where this can be set. In the repo config which lives in the secrets. It's not really a secret but I didn't want to introduce an extra file for this feature.

I also thought about supporting a list of names instead of a single one. But it triggers even more changes, especially in places where there are queries done to the github api. So I decided against it for now at least.