### PR TITLE
slack: send to thread with reply broadcast instead of double-post

### DIFF
--- a/lib/action.ml
+++ b/lib/action.ml
@@ -277,7 +277,6 @@ module Action (Github_api : Api.Github) (Slack_api : Api.Slack) = struct
     let repo = Github.repo_of_notification req in
     let cfg = Context.find_repo_config_exn ctx repo.url in
     let slack_match_func = match_github_login_to_slack_id cfg in
-    let get_thread_permalink = Slack_api.get_thread_permalink in
     match ignore_notifications_from_user cfg req with
     | true -> Lwt.return []
     | false ->
@@ -285,28 +284,18 @@ module Action (Github_api : Api.Github) (Slack_api : Api.Slack) = struct
     | Github.Push n ->
       partition_push cfg n |> List.map (fun (channel, n) -> generate_push_notification n channel) |> Lwt.return
     | Pull_request n ->
-      let%lwt notifications =
-        partition_pr cfg ctx n
-        |> Lwt_list.map_p (generate_pull_request_notification ~ctx ~slack_match_func ~get_thread_permalink n)
-      in
-      Lwt.return @@ List.flatten notifications
+      partition_pr cfg ctx n |> List.map (generate_pull_request_notification ~ctx ~slack_match_func n) |> Lwt.return
     | PR_review n ->
-      let%lwt notifications =
-        partition_pr_review cfg n
-        |> Lwt_list.map_p (generate_pr_review_notification ~ctx ~slack_match_func ~get_thread_permalink n)
-      in
-      Lwt.return @@ List.flatten notifications
+      partition_pr_review cfg n |> List.map (generate_pr_review_notification ~ctx ~slack_match_func n) |> Lwt.return
     | PR_review_comment n ->
       partition_pr_review_comment cfg n
       |> List.map (generate_pr_review_comment_notification ~ctx ~slack_match_func n)
       |> Lwt.return
     | Issue n -> partition_issue cfg n |> List.map (generate_issue_notification ~slack_match_func n) |> Lwt.return
     | Issue_comment n ->
-      let%lwt notifications =
-        partition_issue_comment cfg n
-        |> Lwt_list.map_p (generate_issue_comment_notification ~ctx ~slack_match_func ~get_thread_permalink n)
-      in
-      Lwt.return @@ List.flatten notifications
+      partition_issue_comment cfg n
+      |> List.map (generate_issue_comment_notification ~ctx ~slack_match_func n)
+      |> Lwt.return
     | Commit_comment n ->
       let%lwt channels, api_commit = partition_commit_comment ctx n in
       let notifs = List.map (generate_commit_comment_notification ~slack_match_func api_commit n) channels in

--- a/lib/action.ml
+++ b/lib/action.ml
@@ -291,7 +291,7 @@ module Action (Github_api : Api.Github) (Slack_api : Api.Slack) = struct
       partition_pr_review_comment cfg n
       |> List.map (generate_pr_review_comment_notification ~ctx ~slack_match_func n)
       |> Lwt.return
-    | Issue n -> partition_issue cfg n |> List.map (generate_issue_notification ~slack_match_func n) |> Lwt.return
+    | Issue n -> partition_issue cfg n |> List.map (generate_issue_notification ~ctx ~slack_match_func n) |> Lwt.return
     | Issue_comment n ->
       partition_issue_comment cfg n
       |> List.map (generate_issue_comment_notification ~ctx ~slack_match_func n)

--- a/lib/slack.atd
+++ b/lib/slack.atd
@@ -69,6 +69,7 @@ type post_message_req = {
   ?blocks: message_block list nullable;
   ?unfurl_media : bool nullable;
   ?unfurl_links : bool nullable;
+  ~reply_broadcast <ocaml default="false"> : bool;
 }
 
 type post_message_res = {

--- a/test/slack_payloads.expected
+++ b/test/slack_payloads.expected
@@ -223,7 +223,8 @@ will notify #backend
 {
   "channel": "backend",
   "text": "<https://github.com/xinyuluo/monorepo|[xinyuluo/monorepo]> Issue #6 <https://github.com/xinyuluo/monorepo/issues/6|create a test for issue_notification> closed by *xinyuluo*",
-  "unfurl_links": false
+  "unfurl_links": false,
+  "reply_broadcast": true
 }
 ===== file ../mock_payloads/issues.labeled.json =====
 will notify #backend

--- a/test/slack_payloads.expected
+++ b/test/slack_payloads.expected
@@ -149,7 +149,8 @@ will notify #default
       "text": "handle issue comment"
     }
   ],
-  "unfurl_links": false
+  "unfurl_links": false,
+  "reply_broadcast": true
 }
 ===== file ../mock_payloads/issue_comment.created_in_issue_by_ignored.json =====
 ===== file ../mock_payloads/issue_comment.created_in_pr.json =====
@@ -165,7 +166,8 @@ will notify #a1-bot
       "text": "comment example"
     }
   ],
-  "unfurl_links": false
+  "unfurl_links": false,
+  "reply_broadcast": true
 }
 will notify #backend
 {
@@ -179,7 +181,8 @@ will notify #backend
       "text": "comment example"
     }
   ],
-  "unfurl_links": false
+  "unfurl_links": false,
+  "reply_broadcast": true
 }
 ===== file ../mock_payloads/issue_comment.created_with_mention.json =====
 will notify #default
@@ -194,7 +197,8 @@ will notify #default
       "text": "<@U06PUSUR2Q1> test comment"
     }
   ],
-  "unfurl_links": false
+  "unfurl_links": false,
+  "reply_broadcast": true
 }
 ===== file ../mock_payloads/issue_comment.deleted.json =====
 ===== file ../mock_payloads/issue_comment.draft_pr.json =====
@@ -210,7 +214,8 @@ will notify #frontend-bot
       "text": "> I do not understand this\n\nDo you have access to the logs on the website?"
     }
   ],
-  "unfurl_links": false
+  "unfurl_links": false,
+  "reply_broadcast": true
 }
 ===== file ../mock_payloads/issue_comment.edited.json =====
 ===== file ../mock_payloads/issues.closed.json =====
@@ -277,14 +282,16 @@ will notify #a1-bot
 {
   "channel": "a1-bot",
   "text": "<https://github.com/xinyuluo/monorepo|[xinyuluo/monorepo]> Pull request #8 <https://github.com/xinyuluo/monorepo/pull/8|Update README.md> closed by *xinyuluo*",
-  "unfurl_links": false
+  "unfurl_links": false,
+  "reply_broadcast": true
 }
 ===== file ../mock_payloads/pull_request.closed_no_labels.json =====
 will notify #default
 {
   "channel": "default",
   "text": "<https://github.com/xinyuluo/monorepo|[xinyuluo/monorepo]> Pull request #2 <https://github.com/xinyuluo/monorepo/pull/2|Update README.md> merged by *xinyuluo*",
-  "unfurl_links": false
+  "unfurl_links": false,
+  "reply_broadcast": true
 }
 ===== file ../mock_payloads/pull_request.labeled_two_labels_no_thread.json =====
 ===== file ../mock_payloads/pull_request.labeled_two_labels_with_thread.json =====
@@ -353,20 +360,6 @@ will notify #default
 will notify #default
 {
   "channel": "default",
-  "text": "<https://github.com/Khady/monorepo|[Khady/monorepo]> *Khady* <https://github.com/Khady/monorepo/pull/6#pullrequestreview-0|approved> #6 <https://github.com/Khady/monorepo/pull/6|create pr_review_test.md>",
-  "attachments": [
-    {
-      "fallback": null,
-      "mrkdwn_in": [ "text" ],
-      "color": "#ccc",
-      "text": "*Comment*: approve review\n*Slack thread*: <https://monorobot.slack.com/archives/Cdefault/p1728399554482879?thread_ts=1728399554.482879&cid=Cdefault|comments and reviews>"
-    }
-  ],
-  "unfurl_links": false
-}
-will notify #default
-{
-  "channel": "default",
   "thread_ts": "1728399554.482879",
   "text": "<https://github.com/Khady/monorepo|[Khady/monorepo]> *Khady* <https://github.com/Khady/monorepo/pull/6#pullrequestreview-0|approved> #6 <https://github.com/Khady/monorepo/pull/6|create pr_review_test.md>",
   "attachments": [
@@ -377,23 +370,10 @@ will notify #default
       "text": "approve review"
     }
   ],
-  "unfurl_links": false
+  "unfurl_links": false,
+  "reply_broadcast": true
 }
 ===== file ../mock_payloads/pull_request_review.commented.json =====
-will notify #frontend-bot
-{
-  "channel": "frontend-bot",
-  "text": "<https://github.com/xinyuluo/monorepo|[xinyuluo/monorepo]> *xinyuluo* <https://github.com/xinyuluo/monorepo/pull/3#pullrequestreview-0|reviewed> #3 <https://github.com/xinyuluo/monorepo/pull/3|Update README.md>",
-  "attachments": [
-    {
-      "fallback": null,
-      "mrkdwn_in": [ "text" ],
-      "color": "#ccc",
-      "text": "*Comment*: submit a PR review\n*Slack thread*: <https://monorobot.slack.com/archives/Cfebot/p1728399554482879?thread_ts=1728399554.482879&cid=Cfebot|comments and reviews>"
-    }
-  ],
-  "unfurl_links": false
-}
 will notify #frontend-bot
 {
   "channel": "frontend-bot",
@@ -407,25 +387,12 @@ will notify #frontend-bot
       "text": "submit a PR review"
     }
   ],
-  "unfurl_links": false
+  "unfurl_links": false,
+  "reply_broadcast": true
 }
 ===== file ../mock_payloads/pull_request_review.dismissed.json =====
 ===== file ../mock_payloads/pull_request_review.edited.json =====
 ===== file ../mock_payloads/pull_request_review.request_changes.json =====
-will notify #default
-{
-  "channel": "default",
-  "text": "<https://github.com/Khady/monorepo|[Khady/monorepo]> *Khady* <https://github.com/Khady/monorepo/pull/6#pullrequestreview-0|requested changes on> #6 <https://github.com/Khady/monorepo/pull/6|create pr_review_test.md>",
-  "attachments": [
-    {
-      "fallback": null,
-      "mrkdwn_in": [ "text" ],
-      "color": "#ccc",
-      "text": "*Comment*: request changes review\n*Slack thread*: <https://monorobot.slack.com/archives/Cdefault/p1728399554482879?thread_ts=1728399554.482879&cid=Cdefault|comments and reviews>"
-    }
-  ],
-  "unfurl_links": false
-}
 will notify #default
 {
   "channel": "default",
@@ -439,23 +406,10 @@ will notify #default
       "text": "request changes review"
     }
   ],
-  "unfurl_links": false
+  "unfurl_links": false,
+  "reply_broadcast": true
 }
 ===== file ../mock_payloads/pull_request_review.submitted_comment.json =====
-will notify #frontend-bot
-{
-  "channel": "frontend-bot",
-  "text": "<https://github.com/xinyuluo/monorepo|[xinyuluo/monorepo]> *xinyuluo* <https://github.com/xinyuluo/monorepo/pull/3#pullrequestreview-0|reviewed> #3 <https://github.com/xinyuluo/monorepo/pull/3|Update README.md>",
-  "attachments": [
-    {
-      "fallback": null,
-      "mrkdwn_in": [ "text" ],
-      "color": "#ccc",
-      "text": "*Comment*: This is a great PR, thank you!\n*Slack thread*: <https://monorobot.slack.com/archives/Cfebot/p1728399554482879?thread_ts=1728399554.482879&cid=Cfebot|comments and reviews>"
-    }
-  ],
-  "unfurl_links": false
-}
 will notify #frontend-bot
 {
   "channel": "frontend-bot",
@@ -469,7 +423,8 @@ will notify #frontend-bot
       "text": "This is a great PR, thank you!"
     }
   ],
-  "unfurl_links": false
+  "unfurl_links": false,
+  "reply_broadcast": true
 }
 ===== file ../mock_payloads/pull_request_review.submitted_no_comment.json =====
 ===== file ../mock_payloads/pull_request_review.submitted_null_body.json =====


### PR DESCRIPTION
## Description

This PR builds on the slack thread state tracking enabled by #161, while replacing the double-posting of the same notification to both channel and thread, with a single notification to the thread that is also sent to channel depending on notification type.

## How to test

In promoted test output, duplicate notifications are removed. Notification types that are sent to channel when part of a thread have `reply_broadcast` set to true. (It is harmless for the flag to be enabled when `thread_ts` is absent.) 

Screenshots from test run provided below.
<details>
<summary>channel view</summary>
<img width="648" alt="channel view" src="https://github.com/user-attachments/assets/444c74b1-4c9d-43f5-a3e3-479440158588">
</details>
<details>
<summary>thread view</summary>
<img width="895" alt="thread view" src="https://github.com/user-attachments/assets/79cae0d3-498b-42bd-a5e2-fd9c27e4ef10">
</details>
