### PR TITLE
Dev notifications config for failed and failing builds

### DIFF
--- a/documentation/config_docs.md
+++ b/documentation/config_docs.md
@@ -1,5 +1,4 @@
 # Repository Configuration
-TODO add docs for dev_notifications
 
 A repository configuration file specifies how notifications should be handled for a given repository. It should be at the root of your
 monorepo in the main branch. The bot will look for a `.monorobot.json` file by default, but you can change this behavior with the `--config` flag.
@@ -22,6 +21,15 @@ Refer [here](https://docs.github.com/en/free-pro-team@latest/developers/webhooks
     "user_mappings": {
         "git.user@gitemail.com": "user1@slackemail.com",
         "gh-handle": "user2@slackemail.com"
+    },
+    "notifications_configs": {
+        "dm_for_failing_build": {
+            "user1@slackemail.com": false,
+            "user2@slackemail.com": false
+        },
+        "dm_after_failed_build": {
+            "user1@slackemail.com": true
+        }
     },
     "prefix_rules": {
         ...
@@ -47,8 +55,11 @@ Refer [here](https://docs.github.com/en/free-pro-team@latest/developers/webhooks
 | `project_owners` | project owners config object | no project owners are defined |
 | `ignored_users` | list of users to be ignored on all notifications | no user is ignored |
 | `user_mappings` | list of mappings from git email and/or GitHub handle to Slack email | no mapping defined
+| `notifications_configs` | list of configs for certain types of notifications | dm_for_failing_build defaults to true and dm_after_failed_build to false
 
-Note that in `user_mappings`, git email to Slack email mappings are used for status DMs, while GitHub handle to Slack email mappings are used to get Slack mentions in comment notifications.
+Note that `notifications_configs` expects to match against the email used in slack. It will respect the `user_mappings` rules and then use the resulting slack email to find the correct user id and @mention. If you are not using the `user_mappings` feature, you can directly use the slack email in the `notifications_configs` field.
+
+Also note that in `user_mappings`, git email to Slack email mappings are used for status DMs, while GitHub handle to Slack email mappings are used to get Slack mentions in comment notifications.
 
 The reason for these two separate Slack email matching schemes is that in the case of commits, the git email is available in the GitHub payload and can be used to directly match with Slack emails for status DMs (`user_mappings` can be used to manually override if there is a known mismatch between git email and Slack email). However, for actions done on GitHub itself (e.g. opening PRs, commenting, etc.), usually the only thing available is the GitHub username. To get the email in these cases, a user will have to go to settings and set their email to public, which is (1) hard to enforce if there are many working on the monorepo, and (2) might be undesirable for privacy reasons.
 

--- a/documentation/config_docs.md
+++ b/documentation/config_docs.md
@@ -1,4 +1,5 @@
 # Repository Configuration
+TODO add docs for dev_notifications
 
 A repository configuration file specifies how notifications should be handled for a given repository. It should be at the root of your
 monorepo in the main branch. The bot will look for a `.monorobot.json` file by default, but you can change this behavior with the `--config` flag.

--- a/lib/action.ml
+++ b/lib/action.ml
@@ -164,7 +164,7 @@ module Action (Github_api : Api.Github) (Slack_api : Api.Slack) = struct
           | Ok res ->
             let is_failing_build = Util.Build.is_failing_build n in
             let is_failed_build = Util.Build.is_failed_build n in
-            (* Check if config holds the Github to Slack email mapping for the commit author *)
+            (* Check if config holds Github to Slack email mapping for the commit author *)
             let author = List.assoc_opt email cfg.user_mappings |> Option.default email in
             let dm_after_failed_build =
               List.assoc_opt author cfg.dev_notifications.dm_after_failed_build
@@ -176,22 +176,6 @@ module Action (Github_api : Api.Github) (Slack_api : Api.Slack) = struct
               |> (* dm_for_failing_build is opt out *)
               Option.default true
             in
-            print_endline
-            @@ Printf.sprintf
-                 {|
-
-            ================================================
-            user_id_str: %s
-            finds in config?: %b
-            is_failing_build: %b
-            is_failed_build: %b
-            dm_after_failed_build: %b
-            dm_for_failing_build: %b
-            ================================================
-            |}
-                 author
-                 (Option.is_some (List.assoc_opt author cfg.dev_notifications.dm_after_failed_build))
-                 is_failing_build is_failed_build dm_after_failed_build dm_for_failing_build;
             (match (dm_for_failing_build && is_failing_build) || (dm_after_failed_build && is_failed_build) with
             | true ->
               (* if we send a dm for a failing build and we want another dm after the build is finished, we don't
@@ -199,7 +183,7 @@ module Action (Github_api : Api.Github) (Slack_api : Api.Slack) = struct
               if (is_failing_build && not dm_after_failed_build) || is_failed_build (* TODO: test double opt in *) then
                 State.set_repo_pipeline_commit ctx.state n;
               (* To send a DM, channel parameter is set to the user id of the recipient *)
-              Lwt.return [ Slack_user_id.to_channel_id res.user.id ]
+              Lwt.return [ Status_notification.User res.user.id ]
             | false -> Lwt.return [])
           | Error e ->
             log#warn "couldn't match commit email %s to slack profile: %s" n.commit.commit.author.email e;
@@ -214,13 +198,14 @@ module Action (Github_api : Api.Github) (Slack_api : Api.Slack) = struct
         (* non-main branch build notifications go to default channel to reduce spam in topic channels *)
         match is_main_branch with
         | false ->
-          Lwt.return (Option.map_default (fun c -> [ Slack_channel.to_any c ]) [] cfg.prefix_rules.default_channel)
+          Lwt.return
+            (Option.map_default (fun c -> [ Status_notification.inject_channel c ]) [] cfg.prefix_rules.default_channel)
         | true ->
           (match%lwt Github_api.get_api_commit ~ctx ~repo ~sha:n.commit.sha with
           | Error e -> action_error e
           | Ok commit ->
             let chans = partition_commit cfg commit.files in
-            Lwt.return (List.map Slack_channel.to_any chans))
+            Lwt.return (List.map Status_notification.inject_channel chans))
       in
       (* only notify the failed builds channels for full failed builds with new failed steps on the main branch *)
       let notify_failed_builds_channel =
@@ -243,11 +228,12 @@ module Action (Github_api : Api.Github) (Slack_api : Api.Slack) = struct
           List.find_map
             (fun ({ name; failed_builds_channel } : Config_t.pipeline) ->
               match String.equal name context, failed_builds_channel with
-              | true, Some failed_builds_channel -> Some (Slack_channel.to_any failed_builds_channel :: chans)
+              | true, Some failed_builds_channel ->
+                Some (Status_notification.inject_channel failed_builds_channel :: chans)
               | _ -> None)
             allowed_pipelines
           |> Option.default chans
-          |> List.sort_uniq Slack_channel.compare
+          |> List.sort_uniq Status_notification.compare
         in
         Lwt.return (direct_message @ chans)
     in

--- a/lib/common.ml
+++ b/lib/common.ml
@@ -65,6 +65,25 @@ module StringSet = struct
   let unwrap = to_list
 end
 
+module Status_notification = struct
+  type t =
+    | Channel of Slack_channel.Any.t
+    | User of Slack_user_id.t
+
+  let inject_channel c = Channel (Slack_channel.to_any c)
+
+  let to_slack_channel = function
+    | Channel c -> c
+    | User u -> Slack_user_id.to_channel_id u
+
+  let is_user = function
+    | User _ -> true
+    | Channel _ -> false
+
+  let compare a b = Slack_channel.compare (to_slack_channel a) (to_slack_channel b)
+  let equal a b = compare a b = 0
+end
+
 module Map (S : Map.OrderedType) = struct
   include Map.Make (S)
 

--- a/lib/config.atd
+++ b/lib/config.atd
@@ -35,6 +35,11 @@ type project_owners = {
   rules: project_owners_rule list;
 }
 
+type dev_notifications = {
+  ~dm_for_failing_build <ocaml default="[]">: (string * bool) list <json repr="object">;
+  ~dm_after_failed_build <ocaml default="[]">: (string * bool) list <json repr="object">
+}
+
 (* This is the structure of the repository configuration file. It should be at the
    root of the monorepo, on the main branch. *)
 type config = {
@@ -44,7 +49,8 @@ type config = {
   ~project_owners <ocaml default="{rules = []}"> : project_owners;
   ~ignored_users <ocaml default="[]">: string list; (* list of ignored users *)
   ?main_branch_name : string nullable; (* the name of the main branch; used to filter out notifications about merges of main branch into other branches *)
-  ~user_mappings <ocaml default="[]">: (string * string) list <json repr="object"> (* list of github to slack profile mappings *)
+  ~user_mappings <ocaml default="[]">: (string * string) list <json repr="object">; (* list of github to slack profile mappings *)
+  ~dev_notifications <ocaml default="{dm_after_failed_build = []; dm_for_failing_build = []}"> : dev_notifications;
 }
 
 (* This specifies the Slack webhook to query to post to the channel with the given name *)

--- a/lib/config.atd
+++ b/lib/config.atd
@@ -35,7 +35,7 @@ type project_owners = {
   rules: project_owners_rule list;
 }
 
-type dev_notifications = {
+type notifications_configs = {
   ~dm_for_failing_build <ocaml default="[]">: (string * bool) list <json repr="object">;
   ~dm_after_failed_build <ocaml default="[]">: (string * bool) list <json repr="object">
 }
@@ -50,7 +50,7 @@ type config = {
   ~ignored_users <ocaml default="[]">: string list; (* list of ignored users *)
   ?main_branch_name : string nullable; (* the name of the main branch; used to filter out notifications about merges of main branch into other branches *)
   ~user_mappings <ocaml default="[]">: (string * string) list <json repr="object">; (* list of github to slack profile mappings *)
-  ~dev_notifications <ocaml default="{dm_after_failed_build = []; dm_for_failing_build = []}"> : dev_notifications;
+  ~notifications_configs <ocaml default="{dm_after_failed_build = []; dm_for_failing_build = []}"> : notifications_configs;
 }
 
 (* This specifies the Slack webhook to query to post to the channel with the given name *)

--- a/lib/slack.ml
+++ b/lib/slack.ml
@@ -401,7 +401,6 @@ let generate_status_notification ~(ctx : Context.t) ?slack_user_id (cfg : Config
     match Build.is_failed_build notification && (is_failed_builds_channel || Status_notification.is_user channel) with
     | false -> []
     | true ->
-      (* TODO: don't send @mention on DM notification for failed builds *)
       let repo_state = State.find_or_add_repo ctx.state repository.url in
       let pipeline = notification.context in
       let slack_step_link (s : State_t.failed_step) =

--- a/lib/slack.ml
+++ b/lib/slack.ml
@@ -401,6 +401,7 @@ let generate_status_notification ~(ctx : Context.t) ?slack_user_id (cfg : Config
     match Build.is_failed_build notification && is_failed_builds_channel with
     | false -> []
     | true ->
+      (* TODO: don't send @mention on DM notification for failed builds *)
       let repo_state = State.find_or_add_repo ctx.state repository.url in
       let pipeline = notification.context in
       let slack_step_link (s : State_t.failed_step) =
@@ -415,7 +416,7 @@ let generate_status_notification ~(ctx : Context.t) ?slack_user_id (cfg : Config
   let attachment =
     { empty_attachments with mrkdwn_in = Some [ "fields"; "text" ]; color = Some color_info; text = Some msg }
   in
-  make_message ~text:summary ~attachments:[ attachment ] ~channel:(Slack_channel.to_any channel) ()
+  make_message ~text:summary ~attachments:[ attachment ] ~channel ()
 
 let generate_commit_comment_notification ~slack_match_func api_commit notification channel =
   let { commit; _ } = api_commit in

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -35,6 +35,7 @@ module Build = struct
   }
 
   let buildkite_is_failed_re = Re2.create_exn {|^Build #\d+ failed|}
+  let buildkite_is_failing_re = Re2.create_exn {|^Build #(\d+) is failing|}
 
   let buildkite_is_step_re =
     (* Checks if a pipeline or build step, by looking into the buildkite context
@@ -73,6 +74,9 @@ module Build = struct
 
   let is_failed_build (n : Github_t.status_notification) =
     n.state = Failure && Re2.matches buildkite_is_failed_re (Option.default "" n.description)
+
+  let is_failing_build (n : Github_t.status_notification) =
+    n.state = Failure && Re2.matches buildkite_is_failing_re (Option.default "" n.description)
 
   let new_failed_steps (n : Github_t.status_notification) (repo_state : State_t.repo_state) =
     if not (is_failed_build n) then failwith "Error: new_failed_steps fn must be called on a finished build";


### PR DESCRIPTION
## Description of the task

Extends monorobot config to allow for granular control on failed and failing builds DM notifications. 

Adds a new key to the config: `notifications_configs`, where the users can add their own desired configs and commit to update it in real time, since the config file lives in the repo and not on the server.

Options are: 
- `dm_for_failing_build`: defaults to true (to match current status rules). Determines wether a developer gets a message for a failing build.
- `dm_after_failed_build`: defaults to false (to match current status rules). Determines wether a developer will get a dm after a failed build. This is independent of the `failed_builds_channel` config.

In the end i didn't add tests for this, as it would implicate a lot of overhead for the small  (and not complex) change, but maybe in the future we need to consider adding some unit tests with mocks and/or a way to be able to have a default test `.monorobot.json` config and the ability to have custom ones where it is relevant.