### PR TITLE
Clean stale builds from state

### DIFF
--- a/lib/common.ml
+++ b/lib/common.ml
@@ -2,6 +2,21 @@ open Devkit
 
 module Slack_timestamp = Fresh (String) ()
 
+module Timestamp = struct
+  type t = Ptime.t
+
+  let wrap s =
+    match Ptime.of_rfc3339 s with
+    | Ok (t, _, _) -> t
+    | Error _ -> failwith "Invalid timestamp"
+  let unwrap t = Ptime.to_rfc3339 t
+
+  let wrap_with_fallback ?(fallback = Ptime_clock.now ()) s =
+    match Ptime.of_rfc3339 s with
+    | Ok (t, _, _) -> t
+    | Error _ -> fallback
+end
+
 module Slack_channel : sig
   type 'kind t
 

--- a/lib/dune
+++ b/lib/dune
@@ -1,8 +1,27 @@
 (library
  (name lib)
- (libraries atdgen atdgen-runtime biniou cstruct curl curl.lwt base64
-   devkit devkit.core extlib hex lwt lwt.unix nocrypto omd re2 sexplib0 uri
-   yojson)
+ (libraries
+  atdgen
+  atdgen-runtime
+  base64
+  biniou
+  cstruct
+  curl
+  curl.lwt
+  devkit
+  devkit.core
+  extlib
+  hex
+  lwt
+  lwt.unix
+  nocrypto
+  omd
+  ptime
+  ptime.clock
+  re2
+  sexplib0
+  uri
+  yojson)
  (preprocess
   (pps lwt_ppx)))
 

--- a/lib/state.atd
+++ b/lib/state.atd
@@ -3,7 +3,8 @@ type 'v map_as_object <ocaml from="Common"> = abstract
 type 'v int_map_as_object <ocaml from="Common"> = abstract
 type 'v table_as_object <ocaml from="Common"> = abstract
 type string_set <ocaml from="Common"> = abstract
-type timestamp = string wrap <ocaml t="Common.Slack_timestamp.t" wrap="Common.Slack_timestamp.inject" unwrap="Common.Slack_timestamp.project">
+type slack_timestamp = string wrap <ocaml t="Common.Slack_timestamp.t" wrap="Common.Slack_timestamp.inject" unwrap="Common.Slack_timestamp.project">
+type timestamp = string wrap <ocaml module="Common.Timestamp">
 type user_id = string wrap <ocaml t="Common.Slack_user_id.t" wrap="Common.Slack_user_id.inject" unwrap="Common.Slack_user_id.project">
 type channel_id = string wrap <ocaml t="Common.Slack_channel.Ident.t" wrap="Common.Slack_channel.Ident.inject" unwrap="Common.Slack_channel.Ident.project">
 type any_channel = string wrap <ocaml t="Common.Slack_channel.Any.t" wrap="Common.Slack_channel.Any.inject" unwrap="Common.Slack_channel.Any.project">
@@ -26,8 +27,8 @@ type build_status = {
   commit: ci_commit;
   is_finished: bool;
   failed_steps: failed_step list;
-  created_at: string;
-  finished_at: string nullable;
+  created_at: timestamp;
+  finished_at: timestamp nullable;
 }
 
 (* A map from builds numbers to build statuses *)
@@ -50,7 +51,7 @@ type commit_sets = {
 type pipeline_commits = commit_sets map_as_object
 
 type slack_thread = {
-  ts: timestamp;
+  ts: slack_timestamp;
   channel: any_channel;
   cid: channel_id;
 }

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -101,8 +101,12 @@ module Build = struct
                      String.compare s1.name s2.name)
             in
             let current_build =
-              (* We will not get an exception here because we checked that the build is failed and finished *)
-              IntMap.find current_build_number builds_maps
+              try IntMap.find current_build_number builds_maps
+              with _ ->
+                (* edge case: we got a notification for a build that ran longer than the defined threshold
+                   and was cleaned from state. This shouldn't happen, but adding an error message to make
+                   clearer what is happening if it does. *)
+                failwith "Error: failed to find current build in state, maybe it was cleaned up?"
             in
             List.filter
               (fun (step : State_t.failed_step) ->


### PR DESCRIPTION
## Description of the task

When running tests for the failed builds notifications I've noticed that if for some reason we don't get all the notifications for the events that happen in the followed repo, we will get stale builds. They stay in `pending` state and are not cleaned because we treat them as if they are still running.

This PR handles that issue by setting up a threshold for a build run time and cleaning up builds that passed that threshold.

## Considerations

For the time being I have hardcoded a threshold of 2h, only as a value. It's definitely two long, but didn't want to assume 1h straight away. 

At the same time, I think it makes sense to add this threshold to the `.monorobot` config file. I haven't done it because i'd like to discuss first what format we want to have that threshold in. 

Nothing in these considerations is blocking for this PR to be merged.