### PR TITLE
Add steps types configs

### DIFF
--- a/lib/action.ml
+++ b/lib/action.ml
@@ -168,12 +168,12 @@ module Action (Github_api : Api.Github) (Slack_api : Api.Slack) = struct
                is not an email, so we need to see if we can map the commit author email to a slack user's email. *)
             let author = List.assoc_opt email cfg.user_mappings |> Option.default email in
             let dm_after_failed_build =
-              List.assoc_opt author cfg.notifications_configs.dm_after_failed_build
+              List.assoc_opt author cfg.notifications.dm_after_failed_build
               |> (* dm_after_failed_build is opt in *)
               Option.default false
             in
             let dm_for_failing_build =
-              List.assoc_opt author cfg.notifications_configs.dm_for_failing_build
+              List.assoc_opt author cfg.notifications.dm_for_failing_build
               |> (* dm_for_failing_build is opt out *)
               Option.default true
             in

--- a/lib/config.atd
+++ b/lib/config.atd
@@ -35,9 +35,18 @@ type project_owners = {
   rules: project_owners_rule list;
 }
 
+type steps_types_configs = {
+  build: string list;
+  deploy: string list;
+  test: string list;
+  lint: string list;
+  ignore: string list
+}
+
 type notifications_configs = {
   ~dm_for_failing_build <ocaml default="[]">: (string * bool) list <json repr="object">;
-  ~dm_after_failed_build <ocaml default="[]">: (string * bool) list <json repr="object">
+  ~dm_after_failed_build <ocaml default="[]">: (string * bool) list <json repr="object">;
+  ?steps_config : steps_types_configs nullable
 }
 
 (* This is the structure of the repository configuration file. It should be at the
@@ -50,7 +59,7 @@ type config = {
   ~ignored_users <ocaml default="[]">: string list; (* list of ignored users *)
   ?main_branch_name : string nullable; (* the name of the main branch; used to filter out notifications about merges of main branch into other branches *)
   ~user_mappings <ocaml default="[]">: (string * string) list <json repr="object">; (* list of github to slack profile mappings *)
-  ~notifications_configs <ocaml default="{dm_after_failed_build = []; dm_for_failing_build = []}"> : notifications_configs;
+  ~notifications <ocaml default="{dm_after_failed_build = []; dm_for_failing_build = []; steps_config = None}"> : notifications_configs;
 }
 
 (* This specifies the Slack webhook to query to post to the channel with the given name *)


### PR DESCRIPTION
This PR updates monorobot to allow us to have configs to classify builds steps in defined types, which will allow us to decide on how to handle different types of build steps notifications. For now I just want to update the config to signal the changes being done, and later will add the logic for handling notifications once we agree on it.

I'm not sure sure about the names of the types, but these are likely good enough?

Should this config live inside the allowed pipelines objects? Maybe it makes sense, since monorobot can handle multiple pipelines and repos and maybe we don't want to mix the steps for all of them. This might make automatic generation/update harder.

