### PR TITLE
Add debug db and notification replay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ _opam
 .vscode
 .DS_Store
 secrets.json
+db/monorobot.db
+state.json

--- a/db/sql/status_notifications.sql
+++ b/db/sql/status_notifications.sql
@@ -1,0 +1,56 @@
+-- @ensure_status_notifications_table
+CREATE TABLE IF NOT EXISTS status_notifications (
+    id                          INTEGER PRIMARY KEY,
+    sha                         VARCHAR(40) NOT NULL,
+    notification_text           TEXT NOT NULL,
+    commit_author               VARCHAR(255) NOT NULL,
+    commit_url                  VARCHAR(255) NOT NULL,
+    n_state                     VARCHAR(10) NOT NULL,
+    description                 VARCHAR(255) NOT NULL,
+    target_url                  VARCHAR(255) NOT NULL,
+    build_url                   VARCHAR(255) NOT NULL,
+    build_number                INTEGER NOT NULL,
+    is_step_notification        BOOLEAN NOT NULL,
+    is_canceled                 BOOLEAN NOT NULL,
+    context                     VARCHAR(255) NOT NULL,
+    repository                  VARCHAR(255) NOT NULL,
+    branch                      VARCHAR(255) NOT NULL,
+    matched_rule                VARCHAR(255),
+    last_handled_in             VARCHAR(255) NOT NULL,
+    updated_at                  TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    state_before_notification   TEXT NOT NULL,
+    state_after_notification    TEXT NOT NULL,
+    has_state_update            BOOLEAN NOT NULL DEFAULT false,
+    meta_created_at             TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    meta_updated_at             TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+-- @insert
+INSERT INTO status_notifications VALUES;
+
+-- @update_state
+UPDATE status_notifications SET state_before_notification = @before,
+ state_after_notification = @after, last_handled_in = @last_handled_in, has_state_update = @has_state_update WHERE id = @id;
+
+-- @update_last_handled_in
+UPDATE status_notifications SET last_handled_in = @last_handled_in WHERE id = @id;
+
+-- @update_matched_rule
+UPDATE status_notifications SET matched_rule = @rule WHERE id = @id;
+
+-- @get_by_sha
+SELECT id, last_handled_in, description, notification_text, n_state, has_state_update, state_before_notification, state_after_notification
+FROM status_notifications WHERE sha = ? and context like @pipeline and branch = @branch ORDER BY id DESC;
+
+-- @get_by_build_number
+SELECT id, last_handled_in, description, notification_text, n_state, has_state_update, state_before_notification, state_after_notification
+FROM status_notifications WHERE build_number = ? and context like @pipeline and branch = @branch ORDER BY id DESC;
+
+-- @get_by_range
+SELECT id, last_handled_in, description, notification_text, n_state, has_state_update, state_before_notification, state_after_notification
+FROM status_notifications WHERE build_number > ? and context like @pipeline and branch = @branch ORDER BY id DESC;
+
+-- @get_by_step_name
+SELECT id, last_handled_in, description, notification_text, n_state, has_state_update, state_before_notification, state_after_notification
+FROM status_notifications WHERE context LIKE ? and context like @pipeline and branch = @branch ORDER BY id DESC;
+

--- a/db/sql/status_notifications.sql
+++ b/db/sql/status_notifications.sql
@@ -48,9 +48,9 @@ FROM status_notifications WHERE build_number = ? and context like @pipeline and 
 
 -- @get_by_range
 SELECT id, last_handled_in, description, notification_text, n_state, has_state_update, state_before_notification, state_after_notification
-FROM status_notifications WHERE build_number > ? and context like @pipeline and branch = @branch ORDER BY id DESC;
+FROM status_notifications WHERE build_number > ? and context like @pipeline and branch = @branch ORDER BY build_number desc, id desc;
 
 -- @get_by_step_name
 SELECT id, last_handled_in, description, notification_text, n_state, has_state_update, state_before_notification, state_after_notification
-FROM status_notifications WHERE context LIKE ? and context like @pipeline and branch = @branch ORDER BY id DESC;
+FROM status_notifications WHERE context LIKE ? and context like @pipeline and branch = @branch ORDER BY build_number desc, id DESC;
 

--- a/lib/common.ml
+++ b/lib/common.ml
@@ -120,7 +120,17 @@ module Map (S : Map.OrderedType) = struct
     List.fold_right (fun (k, v) b -> update k (update_f v) b) m empty
 end
 
-module StringMap = Map (String)
+module StringMap = struct
+  include Map (String)
+
+  (** [update_async key f map] updates the value of [key] in [map] using an async function [f].
+      Async equivalent of the [update] function. *)
+  let update_async key f map =
+    let current_value = find_opt key map in
+    match%lwt f current_value with
+    | None -> Lwt.return (remove key map)
+    | Some v -> Lwt.return (add key v map)
+end
 
 module IntMap = Map (Int)
 

--- a/lib/database.ml
+++ b/lib/database.ml
@@ -1,0 +1,194 @@
+type db_status =
+  | Not_available
+  | Uninitialized
+  | Initialized
+
+type 'a db_use_result =
+  | Ok of 'a
+  | Error of string
+  | Db_unavailable
+
+let log = Devkit.Log.from "database"
+
+let db_path = "db/monorobot.db"
+
+let available = ref Not_available
+
+module Conn = struct
+  include Sqlgg_sqlite3
+
+  module IO = struct
+    type 'a future = 'a Lwt.t
+
+    let return = Lwt.return
+
+    let ( >>= ) = Lwt.bind
+
+    let bracket x dtor f =
+      let%lwt x = x in
+      (f x) [%finally dtor x]
+  end
+
+  let finish_params params = Lwt.wrap1 finish_params params
+
+  let no_params params = Lwt.wrap1 no_params params
+
+  let unsafe_wrap set_params stmt = ignore @@ set_params stmt
+
+  let select db sql (set_params : statement -> result IO.future) callback =
+    Lwt.wrap4 select db sql (unsafe_wrap set_params) callback
+
+  let select_one db sql (set_params : statement -> result IO.future) callback =
+    Lwt.wrap4 select_one db sql (unsafe_wrap set_params) callback
+
+  let select_one_maybe db sql (set_params : statement -> result IO.future) callback =
+    Lwt.wrap4 select_one_maybe db sql (unsafe_wrap set_params) callback
+
+  let execute db sql (set_params : statement -> result IO.future) = Lwt.wrap3 execute db sql (unsafe_wrap set_params)
+
+  module Pool : sig
+    type connection = Sqlite3.db
+
+    type t
+
+    val create : max_conn:int -> string -> t Lwt.t
+
+    val use : t -> (connection -> 'a Lwt.t) -> 'a Lwt.t
+
+    val shutdown : t -> unit Lwt.t
+  end = struct
+    type connection = Sqlite3.db
+
+    type t = {
+      pool : connection Lwt_pool.t;
+      mutable connections : connection list;
+    }
+
+    let create ~max_conn db_path =
+      let connections = ref [] in
+
+      let create_connection () =
+        let conn = Sqlite3.db_open db_path in
+        connections := conn :: !connections;
+        Lwt.return conn
+      in
+
+      let dispose_connection conn =
+        connections := List.filter (( != ) conn) !connections;
+        Lwt.return (ignore (Sqlite3.db_close conn))
+      in
+
+      let validate_connection (conn : connection) : bool Lwt.t =
+        try
+          let r = Sqlite3.exec conn "SELECT 1" ~cb:(fun _ _ -> ()) in
+          Lwt.return (r = Sqlite3.Rc.OK)
+        with _ -> Lwt.return false
+      in
+
+      Lwt.return
+        {
+          pool = Lwt_pool.create max_conn ~validate:validate_connection ~dispose:dispose_connection create_connection;
+          connections = !connections;
+        }
+
+    let use t f = Lwt_pool.use t.pool f
+
+    let shutdown t = Lwt_list.iter_p (fun conn -> Lwt.return (ignore (Sqlite3.db_close conn))) t.connections
+  end
+end
+
+type connection = Conn.Pool.connection
+
+let pool : Conn.Pool.t option ref = ref None
+
+let with_db (f : connection -> 'a Lwt.t) : 'a db_use_result Lwt.t =
+  match !available with
+  | Uninitialized ->
+    (* we should never be in this state when this function is called *)
+    assert false
+  | Not_available -> Lwt.return Db_unavailable
+  | Initialized ->
+    let pool = Option.get !pool in
+    (match%lwt Conn.Pool.use pool f with
+    | x -> Lwt.return (Ok x)
+    | exception e -> Lwt.return (Error (Printexc.to_string e)))
+
+module Status_notifications_table = struct
+  include Status_notifications_gen.Make (Conn)
+
+  type n = Github_t.status_notification
+
+  let id' (n : n) = Int64.of_int n.id
+
+  (* We need to have ~is_step_notification, ~is_canceled, and ~last_handled_in as arguments
+     to avoid circular dependencies with the Util module *)
+  let init (n : n) ~notification_text ~build_number ~is_step_notification ~is_canceled last_handled_in =
+    let { Github_t.commit; state; description; target_url; context; branches; updated_at; _ } = n in
+    let { Github_t.commit : Github_t.inner_commit; sha; html_url; _ } = commit in
+    let ({ Github_t.author; _ } : Github_t.inner_commit) = commit in
+    try%lwt
+      match target_url, description with
+      | None, _ | _, None ->
+        (* We don't support notifications without a build url or description *)
+        failwith "missing build url and/or description in the status notification"
+      | Some build_url, Some description ->
+        let branch =
+          match branches with
+          | [] -> failwith "no branches found in the status notification"
+          | [ branch ] -> branch.name
+          | _ -> failwith "multiple branches are not supported in status notification"
+        in
+        let repository = n.repository.url in
+        let state_before_notification = "{}" in
+        let state_after_notification = "{}" in
+        let updated_at = Common.Timestamp.wrap_with_fallback updated_at |> Ptime.to_float_s in
+        let meta_created_at = updated_at in
+        let meta_updated_at = updated_at in
+        let notification_text =
+          (* remove the commit and repository fields from the notification json text without having to manually
+             create a new record and serialize it *)
+          Debug_db_j.(status_notification_of_string notification_text |> string_of_status_notification)
+        in
+        with_db
+          (insert ~id:(id' n) ~notification_text ~sha ~commit_author:author.email ~commit_url:html_url
+             ~n_state:(Github_j.string_of_status_state state) ~description ~target_url:(Option.get target_url)
+             ~build_url ~build_number ~is_step_notification ~is_canceled ~context ~repository ~branch ~last_handled_in
+             ~updated_at ~state_before_notification ~state_after_notification ~meta_created_at ~meta_updated_at
+             ~matched_rule:"" ~has_state_update:false)
+    with e ->
+      let exn_str = Printexc.to_string e in
+      log#error "failed to create status notification: %s" exn_str;
+      Lwt.return (Error exn_str)
+
+  let last_handled_in (n : n) last_handled_in = with_db (update_last_handled_in ~id:(id' n) ~last_handled_in)
+
+  let update_matched_rule (n : n) rule = with_db (update_matched_rule ~id:(id' n) ~rule)
+
+  let update_state (n : n) ?before ~after last_handled_in =
+    let before = Option.map_default State_j.string_of_build_status "{}" before in
+    let after = State_j.string_of_build_status after in
+    with_db (update_state ~id:(id' n) ~before ~after ~last_handled_in ~has_state_update:(before <> after))
+end
+
+module Debug_db = struct
+  module Replay = Status_notifications_gen.Make (Conn)
+  open Replay.Fold
+
+  let run ~pipeline ~branch query v f = with_db (fun dbd -> query dbd ~_0:v ~pipeline ~branch f "")
+
+  let get_by_sha = run get_by_sha
+  let get_by_build_number n = run get_by_build_number (Int64.of_string n)
+  let get_by_range n = run get_by_range (Int64.of_string n)
+  let get_by_step_name = run get_by_step_name
+end
+
+let init ?(max_conn = 10) db_path =
+  let%lwt p = Conn.Pool.create ~max_conn db_path in
+  pool := Some p;
+  available := Initialized;
+  match%lwt with_db Status_notifications_table.ensure_status_notifications_table with
+  | Ok _ -> Lwt.return_unit
+  | Error e -> failwith e
+  | Db_unavailable ->
+    (* this should't happen *)
+    assert false

--- a/lib/database.ml
+++ b/lib/database.ml
@@ -149,12 +149,19 @@ module Status_notifications_table = struct
              create a new record and serialize it *)
           Debug_db_j.(status_notification_of_string notification_text |> string_of_status_notification)
         in
+        let n_state =
+          (* using Github_j.string_of_status state creates a string with quotes inside *)
+          match state with
+          | Pending -> "pending"
+          | Success -> "success"
+          | Error -> "error"
+          | Failure -> "failure"
+        in
         with_db
-          (insert ~id:(id' n) ~notification_text ~sha ~commit_author:author.email ~commit_url:html_url
-             ~n_state:(Github_j.string_of_status_state state) ~description ~target_url:(Option.get target_url)
-             ~build_url ~build_number ~is_step_notification ~is_canceled ~context ~repository ~branch ~last_handled_in
-             ~updated_at ~state_before_notification ~state_after_notification ~meta_created_at ~meta_updated_at
-             ~matched_rule:"" ~has_state_update:false)
+          (insert ~id:(id' n) ~notification_text ~sha ~commit_author:author.email ~commit_url:html_url ~n_state
+             ~description ~target_url:(Option.get target_url) ~build_url ~build_number ~is_step_notification
+             ~is_canceled ~context ~repository ~branch ~last_handled_in ~updated_at ~state_before_notification
+             ~state_after_notification ~meta_created_at ~meta_updated_at ~matched_rule:"" ~has_state_update:false)
     with e ->
       let exn_str = Printexc.to_string e in
       log#error "failed to create status notification: %s" exn_str;

--- a/lib/database.ml
+++ b/lib/database.ml
@@ -165,8 +165,8 @@ module Status_notifications_table = struct
   let update_matched_rule (n : n) rule = with_db (update_matched_rule ~id:(id' n) ~rule)
 
   let update_state (n : n) ?before ~after last_handled_in =
-    let before = Option.map_default State_j.string_of_build_status "{}" before in
-    let after = State_j.string_of_build_status after in
+    let before = Option.map_default State_j.string_of_pipeline_statuses "{}" before in
+    let after = State_j.string_of_pipeline_statuses after in
     with_db (update_state ~id:(id' n) ~before ~after ~last_handled_in ~has_state_update:(before <> after))
 end
 

--- a/lib/debug_db.atd
+++ b/lib/debug_db.atd
@@ -1,0 +1,17 @@
+type commit_hash <ocaml from="Github"> = abstract
+type status_state <ocaml from="Github"> = abstract
+type branch <ocaml from="Github"> = abstract
+
+(* Similar to the github.atd status_notification, but removing the commit and repository fields,
+   since they are quite verbose and not needed for debugging *)
+type status_notification = {
+  id: int;
+  name: string;
+  sha: commit_hash;
+  state: status_state;
+  ?description: string nullable;
+  ?target_url: string nullable;
+  context: string;
+  branches: branch list;
+  updated_at: string;
+}

--- a/lib/debug_db.ml
+++ b/lib/debug_db.ml
@@ -1,0 +1,89 @@
+open Printf
+
+let replay_action db_path pipeline branch only_with_changes after state build_number step_name sha =
+  Lwt_main.run
+    (let db_path = Option.default "db/monorobot.db" db_path in
+     let%lwt () = Database.init db_path in
+     match pipeline, branch with
+     | None, _ | _, None -> failwith "pipeline and branch are required"
+     | Some pipeline, (Some branch : string option) ->
+       (* [<string>%%] is a wildcard to look for any string that starts with [<string>] *)
+       let pipeline = sprintf "%s%%" pipeline in
+       let q, v =
+         let open Database.Debug_db in
+         let args =
+           [
+             "after", Option.map string_of_int after;
+             "build_number", Option.map string_of_int build_number;
+             "sha", sha;
+             "step_name", step_name;
+           ]
+         in
+         match List.filter (fun (_, arg) -> Option.is_some arg) args with
+         | _ :: _ :: _ ->
+           failwith "too many options: the after, build_number, sha and step_name options cannot be used together"
+         | [] ->
+           failwith
+             "no options provided. Please provide a search criteria, like --after, --build-number, --sha, --step-name"
+         | [ ("after", Some after) ] -> get_by_range ~branch ~pipeline, after
+         | [ ("build_number", Some build_number) ] -> get_by_build_number ~branch ~pipeline, build_number
+         | [ ("sha", Some sha) ] -> get_by_sha ~branch ~pipeline, sha
+         | [ ("step_name", Some step_name) ] -> get_by_step_name ~branch ~pipeline, step_name
+         | _ -> failwith "unexpected options"
+       in
+       let fold ~id ~last_handled_in ~description ~notification_text ~n_state ~has_state_update
+         ~state_before_notification ~state_after_notification acc =
+         let row_log =
+           let n = notification_text |> Debug_db_j.status_notification_of_string in
+           let branches_str =
+             sprintf "[%s]" @@ String.concat ", " (List.map (fun (b : Github_t.branch) -> b.name) n.branches)
+           in
+           let print_commit_hash s = String.sub s 0 (min 8 @@ String.length s) in
+           let state_diff =
+             match has_state_update with
+             | false -> "\n"
+             | true ->
+               let json s = Yojson.Basic.(from_string s |> pretty_to_string) in
+               sprintf "# STATE DIFF:\n\n%s\n"
+                 Odiff.(
+                   strings_diffs (json state_before_notification) (json state_after_notification) |> string_of_diffs)
+           in
+           let header =
+             sprintf "[%s] event status: commit=%s, state=%s, context=%s, target_url=%s, branches=%s" n.name
+               (print_commit_hash n.sha)
+               (Github_j.string_of_status_state n.state)
+               n.context (Option.default "none" n.target_url) branches_str
+           in
+           sprintf {|%s
+
+# ID: %Ld
+# DESCRIPTION: %s
+# LAST HANDLED IN: %s
+# HAS STATE UPDATE: %s
+%s|} header id
+             description last_handled_in (string_of_bool has_state_update) state_diff
+         in
+         let keep_row =
+           let with_changes_filter =
+             match only_with_changes with
+             | true when has_state_update -> true
+             | true -> false
+             | false -> true
+           in
+           let state_filter =
+             match state with
+             | None -> true
+             | Some state -> state = Github_j.status_state_of_string n_state
+           in
+           with_changes_filter && state_filter
+         in
+         match keep_row with
+         | false -> acc
+         | true -> sprintf "%s\n%s" row_log acc
+       in
+       (match%lwt q v fold with
+       | Ok log ->
+         print_endline log;
+         Lwt.return_unit
+       | Error e -> failwith e
+       | Db_unavailable -> failwith "database unavailable"))

--- a/lib/dune
+++ b/lib/dune
@@ -13,11 +13,15 @@
   extlib
   lwt
   lwt.unix
+  ocamldiff
   omd
   ptime
   ptime.clock
   re2
   sexplib0
+  sqlgg.sqlite3
+  sqlgg.traits
+  sqlite3
   uri
   yojson)
  (preprocess
@@ -106,3 +110,23 @@
  (deps state.atd)
  (action
   (run atdgen -j -j-std %{deps})))
+
+(rule
+ (targets debug_db_t.ml debug_db_t.mli)
+ (deps debug_db.atd)
+ (action
+  (run atdgen -t %{deps})))
+
+(rule
+ (targets debug_db_j.ml debug_db_j.mli)
+ (deps debug_db.atd)
+ (action
+  (run atdgen -j -j-std %{deps})))
+
+(rule
+ (target status_notifications_gen.ml)
+ (deps ../db/sql/status_notifications.sql)
+ (action
+  (with-stdout-to
+   %{target}
+   (run %{bin:sqlgg} -gen caml_io -name make -params unnamed %{deps}))))

--- a/lib/github.ml
+++ b/lib/github.ml
@@ -160,6 +160,22 @@ let parse_exn ~get_build_branch headers body =
           Lwt.return branches)
     in
     let n = { n with branches = built_branch } in
+    let%lwt () =
+      let open Util.Build in
+      match n.target_url with
+      | None ->
+        (* We don't support notifications without a build url or description *)
+        Lwt.return_unit
+      | Some build_url ->
+        let build_number = get_build_number_exn ~build_url |> Int64.of_int in
+        let is_step_notification = is_pipeline_step n.context in
+        let is_canceled = is_canceled_build n in
+        let%lwt (_ : int64 Database.db_use_result) =
+          Database.Status_notifications_table.init n ~notification_text:body ~build_number ~is_step_notification
+            ~is_canceled "Github.parse_exn"
+        in
+        Lwt.return_unit
+    in
     let branches_str = sprintf "[%s]" @@ String.concat ", " (List.map (fun (b : branch) -> b.name) n.branches) in
     log#info "[%s] event %s: commit=%s, state=%s, context=%s, target_url=%s, branches=%s" n.repository.full_name event
       (print_commit_hash n.commit.sha) (string_of_status_state n.state) n.context (print_opt id n.target_url)

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -56,15 +56,16 @@ module Build = struct
     (* Gets the pipeline name from the buildkite context *)
     Re2.create_exn {|buildkite/([\w_-]+)|}
 
+  let is_pipeline_step context = Re2.matches buildkite_is_step_re context
+
   (** For now we only care about buildkite pipelines and steps. Other CI systems are not supported yet. *)
   let parse_context ~context =
     match Stre.starts_with context "buildkite/" with
     | false -> None
     | true ->
     try
-      let is_pipeline_step = Re2.matches buildkite_is_step_re context in
       let pipeline_name = Re2.find_first_exn ~sub:(`Index 1) buildkite_pipeline_name_re context in
-      Some { is_pipeline_step; pipeline_name }
+      Some { is_pipeline_step = is_pipeline_step context; pipeline_name }
     with _ -> None
 
   let parse_context_exn ~context =
@@ -231,15 +232,27 @@ module Build = struct
               }
             in
             let update_build_status builds_map =
-              let updated_status =
+              let%lwt updated_status =
+                let open Database in
                 match IntMap.find_opt current_build_number builds_map with
-                | Some (current_build_status : State_t.build_status) -> { current_build_status with failed_steps }
-                | None -> init_build_state
+                | Some (current_build_status : State_t.build_status) ->
+                  let updated_build_status = { current_build_status with failed_steps } in
+                  let%lwt (_ : int64 db_use_result) =
+                    Status_notifications_table.update_state n ~before:current_build_status ~after:updated_build_status
+                      "Util.Build.new_failed_steps > get_current_build is Some"
+                  in
+                  Lwt.return updated_build_status
+                | None ->
+                  let%lwt (_ : int64 db_use_result) =
+                    Status_notifications_table.update_state n ~after:init_build_state
+                      "Util.Build.new_failed_steps > get_current_build is None"
+                  in
+                  Lwt.return init_build_state
               in
-              IntMap.add current_build_number updated_status builds_map
+              Lwt.return @@ IntMap.add current_build_number updated_status builds_map
             in
             let update_pipeline_status branches_statuses =
-              let init_branch_state = IntMap.singleton current_build_number init_build_state in
+              let init_branch_state = Lwt.return @@ IntMap.singleton current_build_number init_build_state in
               let current_statuses = Option.default StringMap.empty branches_statuses in
               let updated_statuses =
                 List.map
@@ -255,12 +268,21 @@ module Build = struct
                     branch.name, builds_map)
                   n.branches
               in
-              Some (List.fold_left (fun m (key, data) -> StringMap.add key data m) current_statuses updated_statuses)
+              let%lwt updated =
+                Lwt_list.fold_left_s
+                  (fun m (key, data) ->
+                    let%lwt v = data in
+                    Lwt.return @@ StringMap.add key v m)
+                  current_statuses updated_statuses
+              in
+              Lwt.return_some updated
             in
             (* we need to update the state with the failed steps, otherwise we can't calculate
                the new failed steps in future builds *)
-            repo_state.pipeline_statuses <-
-              StringMap.update pipeline_name update_pipeline_status repo_state.pipeline_statuses;
+            let%lwt updated_status =
+              StringMap.update_async pipeline_name update_pipeline_status repo_state.pipeline_statuses
+            in
+            repo_state.pipeline_statuses <- updated_status;
             Lwt.return failed_steps
           | _ ->
             log#warn "build state for %s is not failed in buildkite. We will not calculate failed steps" build_url;


### PR DESCRIPTION
## Description of the task

Added a debug sqlite database to monorobot to store notifications and state changes to help debug more complex cases where distributed builds might create some confusion as to why some events happen the way they do.

With it, I've added a mechanism to do a simple replay of the notifications.

```bash
$ ./monorobot debug_db replay -p buildkite/buildkite-tests -b main --with-changes -n 523        
QUERY: SELECT id, last_handled_in, notification_text, has_state_update, state_before_notification, state_after_notification FROM status_notifications WHERE context LIKE 'buildkite/buildkite-tests%' AND branch = 'main' AND has_state_update = true AND build_number = '523' order by id desc
[thatportugueseguy/buildkite-starter] event status: commit=12b968aa, state="pending", context=buildkite/buildkite-tests, target_url=https://buildkite.com/monorobot-tests/buildkite-tests/builds/523, branches=[main]

# id: 34299638337
# LAST HANDLED IN: State.set_repo_pipeline_status > update build status > get_current_build is None
# HAS STATE UPDATE: true
# STATE DIFF:

1c1,14
< {}
---
> {
>   "status": "pending",
>   "build_number": 523,
>   "build_url": "https://buildkite.com/monorobot-tests/buildkite-tests/builds/523",
>   "commit": {
>     "sha": "12b968aab7dd0479d491d511b63bfd6a1c438539",
>     "author": "ze@thatportugueseguy.com",
>     "commit_message": "fail 1, notify"
>   },
>   "is_finished": false,
>   "failed_steps": [],
>   "created_at": "2025-02-14T17:18:33-00:00",
>   "finished_at": null
> }


[thatportugueseguy/buildkite-starter] event status: commit=12b968aa, state="failure", context=buildkite/buildkite-tests/test, target_url=https://buildkite.com/monorobot-tests/buildkite-tests/builds/523#01950578-31a3-4354-abb5-995fd895d2d8, branches=[main]

# id: 34299643398
# LAST HANDLED IN: State.set_repo_pipeline_status > update_build_status > get_current_build is Some
# HAS STATE UPDATE: true
# STATE DIFF:

2c2
<   "status": "pending",
---
>   "status": "failure",
11c11,16
<   "failed_steps": [],
---
>   "failed_steps": [
>     {
>       "name": "buildkite/buildkite-tests/test",
>       "build_url": "https://buildkite.com/monorobot-tests/buildkite-tests/builds/523#01950578-31a3-4354-abb5-995fd895d2d8"
>     }
>   ],


[thatportugueseguy/buildkite-starter] event status: commit=12b968aa, state="failure", context=buildkite/buildkite-tests, target_url=https://buildkite.com/monorobot-tests/buildkite-tests/builds/523, branches=[main]

# id: 34299643433
# LAST HANDLED IN: State.set_repo_pipeline_status > update_build_status > get_current_build is Some
# HAS STATE UPDATE: true
# STATE DIFF:

10c10
<   "is_finished": false,
---
>   "is_finished": true,
18c18
<   "finished_at": null
---
>   "finished_at": "2025-02-14T17:18:46-00:00"


[thatportugueseguy/buildkite-starter] event status: commit=12b968aa, state="failure", context=buildkite/buildkite-tests, target_url=https://buildkite.com/monorobot-tests/buildkite-tests/builds/523, branches=[main]

# id: 34299664089
# LAST HANDLED IN: State.set_repo_pipeline_status > update_build_status > get_current_build is Some
# HAS STATE UPDATE: true
# STATE DIFF:

18c18
<   "finished_at": "2025-02-14T17:18:46-00:00"
---
>   "finished_at": "2025-02-14T17:19:37-00:00"
```