### PR TITLE
Let syntax

### DIFF
--- a/lib/api_remote.ml
+++ b/lib/api_remote.ml
@@ -107,7 +107,7 @@ module Slack : Api.Slack = struct
   let log = Log.from "slack"
 
   let slack_api_request ?headers ?body meth url read =
-    let* s = http_request ?headers ?body meth url |> Lwt_result.map_error (fun e -> query_error_msg url e) in
+    let* s = http_request ?headers ?body meth url |> Lwt_result.map_error (query_error_msg url) in
     match Slack_j.slack_response_of_string read s with
     | res -> Lwt.return res
     | exception exn -> Lwt.return_error (query_error_msg url (Exn.to_string exn))
@@ -278,7 +278,7 @@ module Slack : Api.Slack = struct
     with
     | Error `Not_in_channel ->
       let channel = Option.get channel_id in
-      let* _ = join_channel ~ctx channel in
+      let* _res = join_channel ~ctx channel in
       req ~read_error:(default_read_error name) ()
     | Error (`Other e) -> Lwt.return_error e
     | Ok () -> Lwt.return_ok ()

--- a/lib/common.ml
+++ b/lib/common.ml
@@ -1,5 +1,7 @@
 open Devkit
 
+let ( let* ) = Lwt_result.bind
+
 module Slack_timestamp = Fresh (String) ()
 
 module Timestamp = struct
@@ -170,5 +172,3 @@ module Re2 = struct
   let wrap s = create_exn s
   let unwrap = Re2.to_string
 end
-
-let ( let* ) = Lwt_result.bind

--- a/lib/common.ml
+++ b/lib/common.ml
@@ -170,3 +170,5 @@ module Re2 = struct
   let wrap s = create_exn s
   let unwrap = Re2.to_string
 end
+
+let ( let* ) = Lwt_result.bind

--- a/test/slack_payloads.expected
+++ b/test/slack_payloads.expected
@@ -540,26 +540,6 @@ will notify #failed-builds
   ],
   "unfurl_links": false
 }
-will upload file
-{
-  channel_id: "failed-builds",
-  initial_comment: null,
-  thread_ts: "mock_ts",
-  files: [
-    {
-      name: "Test",
-      alt_txt: null,
-      title: null,
-      content: "~~~ Preparing working directory\n\n$ cd /home/emile/.buildkite-agent/builds/emile-tarides-1/monorobot-test-org/monorobot-test-pipeline\n\nPseudo-terminal will not be allocated because stdin is not a terminal.\n\n\n# Host \"github.com\" already in list of known hosts at \"/home/emile/.ssh/known_hosts\"\n\n$ git clean -ffxdq\n\n$ git fetch -v --prune -- origin 404671053ebacf0245dc5b60566eb85e19465860\n\nFrom github.com:EmileTrotignon/monorobot_test\n\n\n * branch            404671053ebacf0245dc5b60566eb85e19465860 -> FETCH_HEAD\n\n\n$ git checkout -f 404671053ebacf0245dc5b60566eb85e19465860\n\nHEAD is now at 4046710 test change\n\n\n# Cleaning again to catch any post-checkout changes\n\n$ git clean -ffxdq\n\n# Checking to see if git commit information needs to be sent to Buildkite...\n\n$ buildkite-agent meta-data exists buildkite:git:commit\n\n# Git commit information has already been sent to Buildkite\n\n~~~ Running commands\n\n$ echo \"Test the rocket\"\n\ndune test\n\nexit 0\n\n\n\nTest the rocket\n\n\nDone: 60% (3/5, 2 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 1)\n                                 \nDone: 77% (7/9, 2 left) (jobs: 1)\n                                 \nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \nFile \"tests/test.t\", line 1, characters 0-0:\n\n\n/usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\ndiff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\nindex 88404ca..a9e2880 100644\n\n\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n\n\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\n@@ -1,2 +1,2 @@\n\n\n   $ dune exec backend\n\n\n-  aaabvaaa\n\n\n+  aaaa\n\n\nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \n^^^ +++\n\n\240\159\154\168 Error: The command exited with status 1\n\n^^^ +++\n\nuser command error: exit status 1\n\n"
-    },
-    {
-      name: "Fail",
-      alt_txt: null,
-      title: null,
-      content: "~~~ Preparing working directory\n\n$ cd /home/emile/.buildkite-agent/builds/emile-tarides-1/monorobot-test-org/monorobot-test-pipeline\n\nPseudo-terminal will not be allocated because stdin is not a terminal.\n\n\n# Host \"github.com\" already in list of known hosts at \"/home/emile/.ssh/known_hosts\"\n\n$ git clean -ffxdq\n\n$ git fetch -v --prune -- origin 404671053ebacf0245dc5b60566eb85e19465860\n\nFrom github.com:EmileTrotignon/monorobot_test\n\n\n * branch            404671053ebacf0245dc5b60566eb85e19465860 -> FETCH_HEAD\n\n\n$ git checkout -f 404671053ebacf0245dc5b60566eb85e19465860\n\nHEAD is now at 4046710 test change\n\n\n# Cleaning again to catch any post-checkout changes\n\n$ git clean -ffxdq\n\n# Checking to see if git commit information needs to be sent to Buildkite...\n\n$ buildkite-agent meta-data exists buildkite:git:commit\n\n# Git commit information has already been sent to Buildkite\n\n~~~ Running commands\n\n$ echo \"Test the rocket\"\n\ndune test\n\nexit 0\n\n\n\nTest the rocket\n\n\nDone: 60% (3/5, 2 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 1)\n                                 \nDone: 77% (7/9, 2 left) (jobs: 1)\n                                 \nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \nFile \"tests/test.t\", line 1, characters 0-0:\n\n\n/usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\ndiff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\nindex 88404ca..a9e2880 100644\n\n\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n\n\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\n@@ -1,2 +1,2 @@\n\n\n   $ dune exec backend\n\n\n-  aaabvaaa\n\n\n+  aaaa\n\n\nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \n^^^ +++\n\n\240\159\154\168 Error: The command exited with status 1\n\n^^^ +++\n\nuser command error: exit status 1\n\n"
-    }
-  ]
-}
 ===== file ../mock_payloads/status.canceled_empty_failed_jobs.json =====
 will notify #failed-builds
 {
@@ -575,26 +555,6 @@ will notify #failed-builds
   ],
   "unfurl_links": false
 }
-will upload file
-{
-  channel_id: "failed-builds",
-  initial_comment: null,
-  thread_ts: "mock_ts",
-  files: [
-    {
-      name: "Test",
-      alt_txt: null,
-      title: null,
-      content: "~~~ Preparing working directory\n\n$ cd /home/emile/.buildkite-agent/builds/emile-tarides-1/monorobot-test-org/monorobot-test-pipeline\n\nPseudo-terminal will not be allocated because stdin is not a terminal.\n\n\n# Host \"github.com\" already in list of known hosts at \"/home/emile/.ssh/known_hosts\"\n\n$ git clean -ffxdq\n\n$ git fetch -v --prune -- origin 404671053ebacf0245dc5b60566eb85e19465860\n\nFrom github.com:EmileTrotignon/monorobot_test\n\n\n * branch            404671053ebacf0245dc5b60566eb85e19465860 -> FETCH_HEAD\n\n\n$ git checkout -f 404671053ebacf0245dc5b60566eb85e19465860\n\nHEAD is now at 4046710 test change\n\n\n# Cleaning again to catch any post-checkout changes\n\n$ git clean -ffxdq\n\n# Checking to see if git commit information needs to be sent to Buildkite...\n\n$ buildkite-agent meta-data exists buildkite:git:commit\n\n# Git commit information has already been sent to Buildkite\n\n~~~ Running commands\n\n$ echo \"Test the rocket\"\n\ndune test\n\nexit 0\n\n\n\nTest the rocket\n\n\nDone: 60% (3/5, 2 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 1)\n                                 \nDone: 77% (7/9, 2 left) (jobs: 1)\n                                 \nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \nFile \"tests/test.t\", line 1, characters 0-0:\n\n\n/usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\ndiff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\nindex 88404ca..a9e2880 100644\n\n\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n\n\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\n@@ -1,2 +1,2 @@\n\n\n   $ dune exec backend\n\n\n-  aaabvaaa\n\n\n+  aaaa\n\n\nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \n^^^ +++\n\n\240\159\154\168 Error: The command exited with status 1\n\n^^^ +++\n\nuser command error: exit status 1\n\n"
-    },
-    {
-      name: "Fail",
-      alt_txt: null,
-      title: null,
-      content: "~~~ Preparing working directory\n\n$ cd /home/emile/.buildkite-agent/builds/emile-tarides-1/monorobot-test-org/monorobot-test-pipeline\n\nPseudo-terminal will not be allocated because stdin is not a terminal.\n\n\n# Host \"github.com\" already in list of known hosts at \"/home/emile/.ssh/known_hosts\"\n\n$ git clean -ffxdq\n\n$ git fetch -v --prune -- origin 404671053ebacf0245dc5b60566eb85e19465860\n\nFrom github.com:EmileTrotignon/monorobot_test\n\n\n * branch            404671053ebacf0245dc5b60566eb85e19465860 -> FETCH_HEAD\n\n\n$ git checkout -f 404671053ebacf0245dc5b60566eb85e19465860\n\nHEAD is now at 4046710 test change\n\n\n# Cleaning again to catch any post-checkout changes\n\n$ git clean -ffxdq\n\n# Checking to see if git commit information needs to be sent to Buildkite...\n\n$ buildkite-agent meta-data exists buildkite:git:commit\n\n# Git commit information has already been sent to Buildkite\n\n~~~ Running commands\n\n$ echo \"Test the rocket\"\n\ndune test\n\nexit 0\n\n\n\nTest the rocket\n\n\nDone: 60% (3/5, 2 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 1)\n                                 \nDone: 77% (7/9, 2 left) (jobs: 1)\n                                 \nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \nFile \"tests/test.t\", line 1, characters 0-0:\n\n\n/usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\ndiff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\nindex 88404ca..a9e2880 100644\n\n\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n\n\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\n@@ -1,2 +1,2 @@\n\n\n   $ dune exec backend\n\n\n-  aaabvaaa\n\n\n+  aaaa\n\n\nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \n^^^ +++\n\n\240\159\154\168 Error: The command exited with status 1\n\n^^^ +++\n\nuser command error: exit status 1\n\n"
-    }
-  ]
-}
 ===== file ../mock_payloads/status.canceled_no_build_state.json =====
 will notify #failed-builds
 {
@@ -609,26 +569,6 @@ will notify #failed-builds
     }
   ],
   "unfurl_links": false
-}
-will upload file
-{
-  channel_id: "failed-builds",
-  initial_comment: null,
-  thread_ts: "mock_ts",
-  files: [
-    {
-      name: "Test",
-      alt_txt: null,
-      title: null,
-      content: "~~~ Preparing working directory\n\n$ cd /home/emile/.buildkite-agent/builds/emile-tarides-1/monorobot-test-org/monorobot-test-pipeline\n\nPseudo-terminal will not be allocated because stdin is not a terminal.\n\n\n# Host \"github.com\" already in list of known hosts at \"/home/emile/.ssh/known_hosts\"\n\n$ git clean -ffxdq\n\n$ git fetch -v --prune -- origin 404671053ebacf0245dc5b60566eb85e19465860\n\nFrom github.com:EmileTrotignon/monorobot_test\n\n\n * branch            404671053ebacf0245dc5b60566eb85e19465860 -> FETCH_HEAD\n\n\n$ git checkout -f 404671053ebacf0245dc5b60566eb85e19465860\n\nHEAD is now at 4046710 test change\n\n\n# Cleaning again to catch any post-checkout changes\n\n$ git clean -ffxdq\n\n# Checking to see if git commit information needs to be sent to Buildkite...\n\n$ buildkite-agent meta-data exists buildkite:git:commit\n\n# Git commit information has already been sent to Buildkite\n\n~~~ Running commands\n\n$ echo \"Test the rocket\"\n\ndune test\n\nexit 0\n\n\n\nTest the rocket\n\n\nDone: 60% (3/5, 2 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 1)\n                                 \nDone: 77% (7/9, 2 left) (jobs: 1)\n                                 \nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \nFile \"tests/test.t\", line 1, characters 0-0:\n\n\n/usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\ndiff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\nindex 88404ca..a9e2880 100644\n\n\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n\n\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\n@@ -1,2 +1,2 @@\n\n\n   $ dune exec backend\n\n\n-  aaabvaaa\n\n\n+  aaaa\n\n\nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \n^^^ +++\n\n\240\159\154\168 Error: The command exited with status 1\n\n^^^ +++\n\nuser command error: exit status 1\n\n"
-    },
-    {
-      name: "Fail",
-      alt_txt: null,
-      title: null,
-      content: "~~~ Preparing working directory\n\n$ cd /home/emile/.buildkite-agent/builds/emile-tarides-1/monorobot-test-org/monorobot-test-pipeline\n\nPseudo-terminal will not be allocated because stdin is not a terminal.\n\n\n# Host \"github.com\" already in list of known hosts at \"/home/emile/.ssh/known_hosts\"\n\n$ git clean -ffxdq\n\n$ git fetch -v --prune -- origin 404671053ebacf0245dc5b60566eb85e19465860\n\nFrom github.com:EmileTrotignon/monorobot_test\n\n\n * branch            404671053ebacf0245dc5b60566eb85e19465860 -> FETCH_HEAD\n\n\n$ git checkout -f 404671053ebacf0245dc5b60566eb85e19465860\n\nHEAD is now at 4046710 test change\n\n\n# Cleaning again to catch any post-checkout changes\n\n$ git clean -ffxdq\n\n# Checking to see if git commit information needs to be sent to Buildkite...\n\n$ buildkite-agent meta-data exists buildkite:git:commit\n\n# Git commit information has already been sent to Buildkite\n\n~~~ Running commands\n\n$ echo \"Test the rocket\"\n\ndune test\n\nexit 0\n\n\n\nTest the rocket\n\n\nDone: 60% (3/5, 2 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 1)\n                                 \nDone: 77% (7/9, 2 left) (jobs: 1)\n                                 \nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \nFile \"tests/test.t\", line 1, characters 0-0:\n\n\n/usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\ndiff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\nindex 88404ca..a9e2880 100644\n\n\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n\n\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\n@@ -1,2 +1,2 @@\n\n\n   $ dune exec backend\n\n\n-  aaabvaaa\n\n\n+  aaaa\n\n\nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \n^^^ +++\n\n\240\159\154\168 Error: The command exited with status 1\n\n^^^ +++\n\nuser command error: exit status 1\n\n"
-    }
-  ]
 }
 ===== file ../mock_payloads/status.canceled_test.json =====
 ===== file ../mock_payloads/status.commit1-01-failing.json =====
@@ -659,6 +599,26 @@ will notify #id[author@ahrefs.com]
     }
   ],
   "unfurl_links": false
+}
+will upload file
+{
+  channel_id: "id[author@ahrefs.com]",
+  initial_comment: null,
+  thread_ts: "mock_ts",
+  files: [
+    {
+      name: "Test",
+      alt_txt: null,
+      title: null,
+      content: "~~~ Preparing working directory\n\n$ cd /home/emile/.buildkite-agent/builds/emile-tarides-1/monorobot-test-org/monorobot-test-pipeline\n\nPseudo-terminal will not be allocated because stdin is not a terminal.\n\n\n# Host \"github.com\" already in list of known hosts at \"/home/emile/.ssh/known_hosts\"\n\n$ git clean -ffxdq\n\n$ git fetch -v --prune -- origin 404671053ebacf0245dc5b60566eb85e19465860\n\nFrom github.com:EmileTrotignon/monorobot_test\n\n\n * branch            404671053ebacf0245dc5b60566eb85e19465860 -> FETCH_HEAD\n\n\n$ git checkout -f 404671053ebacf0245dc5b60566eb85e19465860\n\nHEAD is now at 4046710 test change\n\n\n# Cleaning again to catch any post-checkout changes\n\n$ git clean -ffxdq\n\n# Checking to see if git commit information needs to be sent to Buildkite...\n\n$ buildkite-agent meta-data exists buildkite:git:commit\n\n# Git commit information has already been sent to Buildkite\n\n~~~ Running commands\n\n$ echo \"Test the rocket\"\n\ndune test\n\nexit 0\n\n\n\nTest the rocket\n\n\nDone: 60% (3/5, 2 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 1)\n                                 \nDone: 77% (7/9, 2 left) (jobs: 1)\n                                 \nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \nFile \"tests/test.t\", line 1, characters 0-0:\n\n\n/usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\ndiff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\nindex 88404ca..a9e2880 100644\n\n\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n\n\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\n@@ -1,2 +1,2 @@\n\n\n   $ dune exec backend\n\n\n-  aaabvaaa\n\n\n+  aaaa\n\n\nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \n^^^ +++\n\n\240\159\154\168 Error: The command exited with status 1\n\n^^^ +++\n\nuser command error: exit status 1\n\n"
+    },
+    {
+      name: "Fail",
+      alt_txt: null,
+      title: null,
+      content: "~~~ Preparing working directory\n\n$ cd /home/emile/.buildkite-agent/builds/emile-tarides-1/monorobot-test-org/monorobot-test-pipeline\n\nPseudo-terminal will not be allocated because stdin is not a terminal.\n\n\n# Host \"github.com\" already in list of known hosts at \"/home/emile/.ssh/known_hosts\"\n\n$ git clean -ffxdq\n\n$ git fetch -v --prune -- origin 404671053ebacf0245dc5b60566eb85e19465860\n\nFrom github.com:EmileTrotignon/monorobot_test\n\n\n * branch            404671053ebacf0245dc5b60566eb85e19465860 -> FETCH_HEAD\n\n\n$ git checkout -f 404671053ebacf0245dc5b60566eb85e19465860\n\nHEAD is now at 4046710 test change\n\n\n# Cleaning again to catch any post-checkout changes\n\n$ git clean -ffxdq\n\n# Checking to see if git commit information needs to be sent to Buildkite...\n\n$ buildkite-agent meta-data exists buildkite:git:commit\n\n# Git commit information has already been sent to Buildkite\n\n~~~ Running commands\n\n$ echo \"Test the rocket\"\n\ndune test\n\nexit 0\n\n\n\nTest the rocket\n\n\nDone: 60% (3/5, 2 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 1)\n                                 \nDone: 77% (7/9, 2 left) (jobs: 1)\n                                 \nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \nFile \"tests/test.t\", line 1, characters 0-0:\n\n\n/usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\ndiff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\nindex 88404ca..a9e2880 100644\n\n\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n\n\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\n@@ -1,2 +1,2 @@\n\n\n   $ dune exec backend\n\n\n-  aaabvaaa\n\n\n+  aaaa\n\n\nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \n^^^ +++\n\n\240\159\154\168 Error: The command exited with status 1\n\n^^^ +++\n\nuser command error: exit status 1\n\n"
+    }
+  ]
 }
 ===== file ../mock_payloads/status.commit1-02-failed.json =====
 will notify #default
@@ -719,26 +679,6 @@ will notify #failed-builds
   ],
   "unfurl_links": false
 }
-will upload file
-{
-  channel_id: "failed-builds",
-  initial_comment: null,
-  thread_ts: "mock_ts",
-  files: [
-    {
-      name: "Test",
-      alt_txt: null,
-      title: null,
-      content: "~~~ Preparing working directory\n\n$ cd /home/emile/.buildkite-agent/builds/emile-tarides-1/monorobot-test-org/monorobot-test-pipeline\n\nPseudo-terminal will not be allocated because stdin is not a terminal.\n\n\n# Host \"github.com\" already in list of known hosts at \"/home/emile/.ssh/known_hosts\"\n\n$ git clean -ffxdq\n\n$ git fetch -v --prune -- origin 404671053ebacf0245dc5b60566eb85e19465860\n\nFrom github.com:EmileTrotignon/monorobot_test\n\n\n * branch            404671053ebacf0245dc5b60566eb85e19465860 -> FETCH_HEAD\n\n\n$ git checkout -f 404671053ebacf0245dc5b60566eb85e19465860\n\nHEAD is now at 4046710 test change\n\n\n# Cleaning again to catch any post-checkout changes\n\n$ git clean -ffxdq\n\n# Checking to see if git commit information needs to be sent to Buildkite...\n\n$ buildkite-agent meta-data exists buildkite:git:commit\n\n# Git commit information has already been sent to Buildkite\n\n~~~ Running commands\n\n$ echo \"Test the rocket\"\n\ndune test\n\nexit 0\n\n\n\nTest the rocket\n\n\nDone: 60% (3/5, 2 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 1)\n                                 \nDone: 77% (7/9, 2 left) (jobs: 1)\n                                 \nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \nFile \"tests/test.t\", line 1, characters 0-0:\n\n\n/usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\ndiff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\nindex 88404ca..a9e2880 100644\n\n\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n\n\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\n@@ -1,2 +1,2 @@\n\n\n   $ dune exec backend\n\n\n-  aaabvaaa\n\n\n+  aaaa\n\n\nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \n^^^ +++\n\n\240\159\154\168 Error: The command exited with status 1\n\n^^^ +++\n\nuser command error: exit status 1\n\n"
-    },
-    {
-      name: "Fail",
-      alt_txt: null,
-      title: null,
-      content: "~~~ Preparing working directory\n\n$ cd /home/emile/.buildkite-agent/builds/emile-tarides-1/monorobot-test-org/monorobot-test-pipeline\n\nPseudo-terminal will not be allocated because stdin is not a terminal.\n\n\n# Host \"github.com\" already in list of known hosts at \"/home/emile/.ssh/known_hosts\"\n\n$ git clean -ffxdq\n\n$ git fetch -v --prune -- origin 404671053ebacf0245dc5b60566eb85e19465860\n\nFrom github.com:EmileTrotignon/monorobot_test\n\n\n * branch            404671053ebacf0245dc5b60566eb85e19465860 -> FETCH_HEAD\n\n\n$ git checkout -f 404671053ebacf0245dc5b60566eb85e19465860\n\nHEAD is now at 4046710 test change\n\n\n# Cleaning again to catch any post-checkout changes\n\n$ git clean -ffxdq\n\n# Checking to see if git commit information needs to be sent to Buildkite...\n\n$ buildkite-agent meta-data exists buildkite:git:commit\n\n# Git commit information has already been sent to Buildkite\n\n~~~ Running commands\n\n$ echo \"Test the rocket\"\n\ndune test\n\nexit 0\n\n\n\nTest the rocket\n\n\nDone: 60% (3/5, 2 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 1)\n                                 \nDone: 77% (7/9, 2 left) (jobs: 1)\n                                 \nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \nFile \"tests/test.t\", line 1, characters 0-0:\n\n\n/usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\ndiff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\nindex 88404ca..a9e2880 100644\n\n\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n\n\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\n@@ -1,2 +1,2 @@\n\n\n   $ dune exec backend\n\n\n-  aaabvaaa\n\n\n+  aaaa\n\n\nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \n^^^ +++\n\n\240\159\154\168 Error: The command exited with status 1\n\n^^^ +++\n\nuser command error: exit status 1\n\n"
-    }
-  ]
-}
 ===== file ../mock_payloads/status.commit1-02-failed_no_failed_builds_chan.json =====
 will notify #default
 {
@@ -769,26 +709,6 @@ will notify #failed-builds
   ],
   "unfurl_links": false
 }
-will upload file
-{
-  channel_id: "failed-builds",
-  initial_comment: null,
-  thread_ts: "mock_ts",
-  files: [
-    {
-      name: "Test",
-      alt_txt: null,
-      title: null,
-      content: "~~~ Preparing working directory\n\n$ cd /home/emile/.buildkite-agent/builds/emile-tarides-1/monorobot-test-org/monorobot-test-pipeline\n\nPseudo-terminal will not be allocated because stdin is not a terminal.\n\n\n# Host \"github.com\" already in list of known hosts at \"/home/emile/.ssh/known_hosts\"\n\n$ git clean -ffxdq\n\n$ git fetch -v --prune -- origin 404671053ebacf0245dc5b60566eb85e19465860\n\nFrom github.com:EmileTrotignon/monorobot_test\n\n\n * branch            404671053ebacf0245dc5b60566eb85e19465860 -> FETCH_HEAD\n\n\n$ git checkout -f 404671053ebacf0245dc5b60566eb85e19465860\n\nHEAD is now at 4046710 test change\n\n\n# Cleaning again to catch any post-checkout changes\n\n$ git clean -ffxdq\n\n# Checking to see if git commit information needs to be sent to Buildkite...\n\n$ buildkite-agent meta-data exists buildkite:git:commit\n\n# Git commit information has already been sent to Buildkite\n\n~~~ Running commands\n\n$ echo \"Test the rocket\"\n\ndune test\n\nexit 0\n\n\n\nTest the rocket\n\n\nDone: 60% (3/5, 2 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 1)\n                                 \nDone: 77% (7/9, 2 left) (jobs: 1)\n                                 \nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \nFile \"tests/test.t\", line 1, characters 0-0:\n\n\n/usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\ndiff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\nindex 88404ca..a9e2880 100644\n\n\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n\n\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\n@@ -1,2 +1,2 @@\n\n\n   $ dune exec backend\n\n\n-  aaabvaaa\n\n\n+  aaaa\n\n\nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \n^^^ +++\n\n\240\159\154\168 Error: The command exited with status 1\n\n^^^ +++\n\nuser command error: exit status 1\n\n"
-    },
-    {
-      name: "Fail",
-      alt_txt: null,
-      title: null,
-      content: "~~~ Preparing working directory\n\n$ cd /home/emile/.buildkite-agent/builds/emile-tarides-1/monorobot-test-org/monorobot-test-pipeline\n\nPseudo-terminal will not be allocated because stdin is not a terminal.\n\n\n# Host \"github.com\" already in list of known hosts at \"/home/emile/.ssh/known_hosts\"\n\n$ git clean -ffxdq\n\n$ git fetch -v --prune -- origin 404671053ebacf0245dc5b60566eb85e19465860\n\nFrom github.com:EmileTrotignon/monorobot_test\n\n\n * branch            404671053ebacf0245dc5b60566eb85e19465860 -> FETCH_HEAD\n\n\n$ git checkout -f 404671053ebacf0245dc5b60566eb85e19465860\n\nHEAD is now at 4046710 test change\n\n\n# Cleaning again to catch any post-checkout changes\n\n$ git clean -ffxdq\n\n# Checking to see if git commit information needs to be sent to Buildkite...\n\n$ buildkite-agent meta-data exists buildkite:git:commit\n\n# Git commit information has already been sent to Buildkite\n\n~~~ Running commands\n\n$ echo \"Test the rocket\"\n\ndune test\n\nexit 0\n\n\n\nTest the rocket\n\n\nDone: 60% (3/5, 2 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 1)\n                                 \nDone: 77% (7/9, 2 left) (jobs: 1)\n                                 \nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \nFile \"tests/test.t\", line 1, characters 0-0:\n\n\n/usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\ndiff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\nindex 88404ca..a9e2880 100644\n\n\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n\n\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\n@@ -1,2 +1,2 @@\n\n\n   $ dune exec backend\n\n\n-  aaabvaaa\n\n\n+  aaaa\n\n\nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \n^^^ +++\n\n\240\159\154\168 Error: The command exited with status 1\n\n^^^ +++\n\nuser command error: exit status 1\n\n"
-    }
-  ]
-}
 ===== file ../mock_payloads/status.failed_empty_failed_jobs.json =====
 will notify #failed-builds
 {
@@ -803,26 +723,6 @@ will notify #failed-builds
     }
   ],
   "unfurl_links": false
-}
-will upload file
-{
-  channel_id: "failed-builds",
-  initial_comment: null,
-  thread_ts: "mock_ts",
-  files: [
-    {
-      name: "Test",
-      alt_txt: null,
-      title: null,
-      content: "~~~ Preparing working directory\n\n$ cd /home/emile/.buildkite-agent/builds/emile-tarides-1/monorobot-test-org/monorobot-test-pipeline\n\nPseudo-terminal will not be allocated because stdin is not a terminal.\n\n\n# Host \"github.com\" already in list of known hosts at \"/home/emile/.ssh/known_hosts\"\n\n$ git clean -ffxdq\n\n$ git fetch -v --prune -- origin 404671053ebacf0245dc5b60566eb85e19465860\n\nFrom github.com:EmileTrotignon/monorobot_test\n\n\n * branch            404671053ebacf0245dc5b60566eb85e19465860 -> FETCH_HEAD\n\n\n$ git checkout -f 404671053ebacf0245dc5b60566eb85e19465860\n\nHEAD is now at 4046710 test change\n\n\n# Cleaning again to catch any post-checkout changes\n\n$ git clean -ffxdq\n\n# Checking to see if git commit information needs to be sent to Buildkite...\n\n$ buildkite-agent meta-data exists buildkite:git:commit\n\n# Git commit information has already been sent to Buildkite\n\n~~~ Running commands\n\n$ echo \"Test the rocket\"\n\ndune test\n\nexit 0\n\n\n\nTest the rocket\n\n\nDone: 60% (3/5, 2 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 1)\n                                 \nDone: 77% (7/9, 2 left) (jobs: 1)\n                                 \nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \nFile \"tests/test.t\", line 1, characters 0-0:\n\n\n/usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\ndiff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\nindex 88404ca..a9e2880 100644\n\n\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n\n\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\n@@ -1,2 +1,2 @@\n\n\n   $ dune exec backend\n\n\n-  aaabvaaa\n\n\n+  aaaa\n\n\nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \n^^^ +++\n\n\240\159\154\168 Error: The command exited with status 1\n\n^^^ +++\n\nuser command error: exit status 1\n\n"
-    },
-    {
-      name: "Fail",
-      alt_txt: null,
-      title: null,
-      content: "~~~ Preparing working directory\n\n$ cd /home/emile/.buildkite-agent/builds/emile-tarides-1/monorobot-test-org/monorobot-test-pipeline\n\nPseudo-terminal will not be allocated because stdin is not a terminal.\n\n\n# Host \"github.com\" already in list of known hosts at \"/home/emile/.ssh/known_hosts\"\n\n$ git clean -ffxdq\n\n$ git fetch -v --prune -- origin 404671053ebacf0245dc5b60566eb85e19465860\n\nFrom github.com:EmileTrotignon/monorobot_test\n\n\n * branch            404671053ebacf0245dc5b60566eb85e19465860 -> FETCH_HEAD\n\n\n$ git checkout -f 404671053ebacf0245dc5b60566eb85e19465860\n\nHEAD is now at 4046710 test change\n\n\n# Cleaning again to catch any post-checkout changes\n\n$ git clean -ffxdq\n\n# Checking to see if git commit information needs to be sent to Buildkite...\n\n$ buildkite-agent meta-data exists buildkite:git:commit\n\n# Git commit information has already been sent to Buildkite\n\n~~~ Running commands\n\n$ echo \"Test the rocket\"\n\ndune test\n\nexit 0\n\n\n\nTest the rocket\n\n\nDone: 60% (3/5, 2 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 1)\n                                 \nDone: 77% (7/9, 2 left) (jobs: 1)\n                                 \nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \nFile \"tests/test.t\", line 1, characters 0-0:\n\n\n/usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\ndiff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\nindex 88404ca..a9e2880 100644\n\n\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n\n\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\n@@ -1,2 +1,2 @@\n\n\n   $ dune exec backend\n\n\n-  aaabvaaa\n\n\n+  aaaa\n\n\nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \n^^^ +++\n\n\240\159\154\168 Error: The command exited with status 1\n\n^^^ +++\n\nuser command error: exit status 1\n\n"
-    }
-  ]
 }
 ===== file ../mock_payloads/status.failed_multiple_branches.json =====
 will notify #default
@@ -854,26 +754,6 @@ will notify #failed-builds
   ],
   "unfurl_links": false
 }
-will upload file
-{
-  channel_id: "failed-builds",
-  initial_comment: null,
-  thread_ts: "mock_ts",
-  files: [
-    {
-      name: "Test",
-      alt_txt: null,
-      title: null,
-      content: "~~~ Preparing working directory\n\n$ cd /home/emile/.buildkite-agent/builds/emile-tarides-1/monorobot-test-org/monorobot-test-pipeline\n\nPseudo-terminal will not be allocated because stdin is not a terminal.\n\n\n# Host \"github.com\" already in list of known hosts at \"/home/emile/.ssh/known_hosts\"\n\n$ git clean -ffxdq\n\n$ git fetch -v --prune -- origin 404671053ebacf0245dc5b60566eb85e19465860\n\nFrom github.com:EmileTrotignon/monorobot_test\n\n\n * branch            404671053ebacf0245dc5b60566eb85e19465860 -> FETCH_HEAD\n\n\n$ git checkout -f 404671053ebacf0245dc5b60566eb85e19465860\n\nHEAD is now at 4046710 test change\n\n\n# Cleaning again to catch any post-checkout changes\n\n$ git clean -ffxdq\n\n# Checking to see if git commit information needs to be sent to Buildkite...\n\n$ buildkite-agent meta-data exists buildkite:git:commit\n\n# Git commit information has already been sent to Buildkite\n\n~~~ Running commands\n\n$ echo \"Test the rocket\"\n\ndune test\n\nexit 0\n\n\n\nTest the rocket\n\n\nDone: 60% (3/5, 2 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 1)\n                                 \nDone: 77% (7/9, 2 left) (jobs: 1)\n                                 \nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \nFile \"tests/test.t\", line 1, characters 0-0:\n\n\n/usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\ndiff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\nindex 88404ca..a9e2880 100644\n\n\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n\n\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\n@@ -1,2 +1,2 @@\n\n\n   $ dune exec backend\n\n\n-  aaabvaaa\n\n\n+  aaaa\n\n\nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \n^^^ +++\n\n\240\159\154\168 Error: The command exited with status 1\n\n^^^ +++\n\nuser command error: exit status 1\n\n"
-    },
-    {
-      name: "Fail",
-      alt_txt: null,
-      title: null,
-      content: "~~~ Preparing working directory\n\n$ cd /home/emile/.buildkite-agent/builds/emile-tarides-1/monorobot-test-org/monorobot-test-pipeline\n\nPseudo-terminal will not be allocated because stdin is not a terminal.\n\n\n# Host \"github.com\" already in list of known hosts at \"/home/emile/.ssh/known_hosts\"\n\n$ git clean -ffxdq\n\n$ git fetch -v --prune -- origin 404671053ebacf0245dc5b60566eb85e19465860\n\nFrom github.com:EmileTrotignon/monorobot_test\n\n\n * branch            404671053ebacf0245dc5b60566eb85e19465860 -> FETCH_HEAD\n\n\n$ git checkout -f 404671053ebacf0245dc5b60566eb85e19465860\n\nHEAD is now at 4046710 test change\n\n\n# Cleaning again to catch any post-checkout changes\n\n$ git clean -ffxdq\n\n# Checking to see if git commit information needs to be sent to Buildkite...\n\n$ buildkite-agent meta-data exists buildkite:git:commit\n\n# Git commit information has already been sent to Buildkite\n\n~~~ Running commands\n\n$ echo \"Test the rocket\"\n\ndune test\n\nexit 0\n\n\n\nTest the rocket\n\n\nDone: 60% (3/5, 2 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 1)\n                                 \nDone: 77% (7/9, 2 left) (jobs: 1)\n                                 \nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \nFile \"tests/test.t\", line 1, characters 0-0:\n\n\n/usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\ndiff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\nindex 88404ca..a9e2880 100644\n\n\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n\n\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\n@@ -1,2 +1,2 @@\n\n\n   $ dune exec backend\n\n\n-  aaabvaaa\n\n\n+  aaaa\n\n\nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \n^^^ +++\n\n\240\159\154\168 Error: The command exited with status 1\n\n^^^ +++\n\nuser command error: exit status 1\n\n"
-    }
-  ]
-}
 ===== file ../mock_payloads/status.failure_test.json =====
 ===== file ../mock_payloads/status.failure_test_main_branch.json =====
 will notify #all-push-events
@@ -903,26 +783,6 @@ will notify #failed-builds
     }
   ],
   "unfurl_links": false
-}
-will upload file
-{
-  channel_id: "failed-builds",
-  initial_comment: null,
-  thread_ts: "mock_ts",
-  files: [
-    {
-      name: "Test",
-      alt_txt: null,
-      title: null,
-      content: "~~~ Preparing working directory\n\n$ cd /home/emile/.buildkite-agent/builds/emile-tarides-1/monorobot-test-org/monorobot-test-pipeline\n\nPseudo-terminal will not be allocated because stdin is not a terminal.\n\n\n# Host \"github.com\" already in list of known hosts at \"/home/emile/.ssh/known_hosts\"\n\n$ git clean -ffxdq\n\n$ git fetch -v --prune -- origin 404671053ebacf0245dc5b60566eb85e19465860\n\nFrom github.com:EmileTrotignon/monorobot_test\n\n\n * branch            404671053ebacf0245dc5b60566eb85e19465860 -> FETCH_HEAD\n\n\n$ git checkout -f 404671053ebacf0245dc5b60566eb85e19465860\n\nHEAD is now at 4046710 test change\n\n\n# Cleaning again to catch any post-checkout changes\n\n$ git clean -ffxdq\n\n# Checking to see if git commit information needs to be sent to Buildkite...\n\n$ buildkite-agent meta-data exists buildkite:git:commit\n\n# Git commit information has already been sent to Buildkite\n\n~~~ Running commands\n\n$ echo \"Test the rocket\"\n\ndune test\n\nexit 0\n\n\n\nTest the rocket\n\n\nDone: 60% (3/5, 2 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 1)\n                                 \nDone: 77% (7/9, 2 left) (jobs: 1)\n                                 \nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \nFile \"tests/test.t\", line 1, characters 0-0:\n\n\n/usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\ndiff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\nindex 88404ca..a9e2880 100644\n\n\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n\n\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\n@@ -1,2 +1,2 @@\n\n\n   $ dune exec backend\n\n\n-  aaabvaaa\n\n\n+  aaaa\n\n\nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \n^^^ +++\n\n\240\159\154\168 Error: The command exited with status 1\n\n^^^ +++\n\nuser command error: exit status 1\n\n"
-    },
-    {
-      name: "Fail",
-      alt_txt: null,
-      title: null,
-      content: "~~~ Preparing working directory\n\n$ cd /home/emile/.buildkite-agent/builds/emile-tarides-1/monorobot-test-org/monorobot-test-pipeline\n\nPseudo-terminal will not be allocated because stdin is not a terminal.\n\n\n# Host \"github.com\" already in list of known hosts at \"/home/emile/.ssh/known_hosts\"\n\n$ git clean -ffxdq\n\n$ git fetch -v --prune -- origin 404671053ebacf0245dc5b60566eb85e19465860\n\nFrom github.com:EmileTrotignon/monorobot_test\n\n\n * branch            404671053ebacf0245dc5b60566eb85e19465860 -> FETCH_HEAD\n\n\n$ git checkout -f 404671053ebacf0245dc5b60566eb85e19465860\n\nHEAD is now at 4046710 test change\n\n\n# Cleaning again to catch any post-checkout changes\n\n$ git clean -ffxdq\n\n# Checking to see if git commit information needs to be sent to Buildkite...\n\n$ buildkite-agent meta-data exists buildkite:git:commit\n\n# Git commit information has already been sent to Buildkite\n\n~~~ Running commands\n\n$ echo \"Test the rocket\"\n\ndune test\n\nexit 0\n\n\n\nTest the rocket\n\n\nDone: 60% (3/5, 2 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 0)\n                                 \nDone: 55% (5/9, 4 left) (jobs: 1)\n                                 \nDone: 77% (7/9, 2 left) (jobs: 1)\n                                 \nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \nFile \"tests/test.t\", line 1, characters 0-0:\n\n\n/usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\ndiff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\nindex 88404ca..a9e2880 100644\n\n\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n\n\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n\n\n@@ -1,2 +1,2 @@\n\n\n   $ dune exec backend\n\n\n-  aaabvaaa\n\n\n+  aaaa\n\n\nDone: 90% (9/10, 1 left) (jobs: 1)\n                                  \n^^^ +++\n\n\240\159\154\168 Error: The command exited with status 1\n\n^^^ +++\n\nuser command error: exit status 1\n\n"
-    }
-  ]
 }
 ===== file ../mock_payloads/status.failure_test_no_failed_builds_chan.json =====
 will notify #default


### PR DESCRIPTION
This introduces let syntax in monorobot.

It `let*` instead of `let%bind` even though the coding style guide says to let%bind, because let%bind would be an extra dependency, and this is a relatively simple project that has little exceptions, so stack traces are not a big concern. I would still like feedback on this topic though.  

There are two commit, the first one introduces let*, the second one uses Let_result.map_error to enable more uses of let*.