### PR TITLE
remove webhook mode

### DIFF
--- a/lib/action.ml
+++ b/lib/action.ml
@@ -440,16 +440,15 @@ module Action (Github_api : Api.Github) (Slack_api : Api.Slack) (Buildkite_api :
   let send_notifications (ctx : Context.t) notifications =
     let notify (msg, handler) =
       match%lwt Slack_api.send_notification ~ctx ~msg with
-      | Ok (Some res) ->
-        (match handler with
-        | None -> Lwt.return_unit
-        | Some handler ->
-          (match%lwt handler res with
-          | Result.Error e -> handler_error e
-          | Ok () -> Lwt.return_unit
-          | exception exn -> handler_error (Printexc.to_string exn)))
-      | Ok None -> Lwt.return_unit
       | Error e -> action_error e
+      | Ok res ->
+      match handler with
+      | None -> Lwt.return_unit
+      | Some handler ->
+        (match%lwt handler res with
+        | Result.Error e -> handler_error e
+        | Ok () -> Lwt.return_unit
+        | exception exn -> handler_error (Printexc.to_string exn))
     in
     Lwt_list.iter_s notify notifications
 

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -23,7 +23,7 @@ module type Slack = sig
     lookup_user_res slack_response Lwt.t
 
   val list_users : ?cursor:string -> ?limit:int -> ctx:Context.t -> unit -> list_users_res slack_response Lwt.t
-  val send_notification : ctx:Context.t -> msg:post_message_req -> post_message_res option slack_response Lwt.t
+  val send_notification : ctx:Context.t -> msg:post_message_req -> post_message_res slack_response Lwt.t
 
   val send_chat_unfurl :
     ctx:Context.t ->

--- a/lib/api_local.ml
+++ b/lib/api_local.ml
@@ -107,7 +107,9 @@ module Slack_simple : Api.Slack = struct
       (match msg.Slack_t.text with
       | None -> ""
       | Some s -> sprintf " with %S" s);
-    Lwt.return @@ Ok None
+    let channel = Slack_channel.Ident.inject (Slack_channel.Any.project msg.channel) in
+    let res = ({ Slack_t.channel; ts = Slack_timestamp.inject "mock_ts" } : Slack_t.post_message_res) in
+    Lwt.return_ok res
 
   let send_file ~ctx:_ ~(file : Slack.file_req) =
     let json = string_of_file_req file in
@@ -147,7 +149,7 @@ module Slack_json : Api.Slack = struct
     log#info "%s" json;
     let channel = Slack_channel.Ident.inject (Slack_channel.Any.project msg.channel) in
     let res = ({ Slack_t.channel; ts = Slack_timestamp.inject "mock_ts" } : Slack_t.post_message_res) in
-    Lwt.return_ok (Some res)
+    Lwt.return_ok res
 
   let send_file ~ctx:_ ~(file : Slack.file_req) =
     let json = string_of_file_req file in
@@ -190,7 +192,7 @@ module Slack : Api.Slack = struct
     Printf.printf "%s\n" json;
     let channel = Slack_channel.Ident.inject (Slack_channel.Any.project msg.channel) in
     let res = ({ Slack_t.channel; ts = Slack_timestamp.inject "mock_ts" } : Slack_t.post_message_res) in
-    Lwt.return @@ Ok (Some res)
+    Lwt.return @@ Ok res
 
   let send_file ~ctx:_ ~(file : Slack.file_req) =
     let json = string_of_file_req file in

--- a/lib/api_remote.ml
+++ b/lib/api_remote.ml
@@ -171,13 +171,13 @@ module Slack : Api.Slack = struct
     log#info "sending to %s" (Slack_channel.Any.project msg.channel);
     let build_error e = sprintf "%s\nfailed to send Slack notification" e in
     let secrets = Context.get_secrets_exn ctx in
-    let headers, url, webhook_mode =
+    let headers, url =
       match Context.hook_of_channel ctx msg.channel with
-      | Some url -> [], Some url, true
+      | Some url -> [], Some url
       | None ->
       match secrets.slack_access_token with
-      | Some access_token -> [ bearer_token_header access_token ], Some "https://slack.com/api/chat.postMessage", false
-      | None -> [], None, false
+      | Some access_token -> [ bearer_token_header access_token ], Some "https://slack.com/api/chat.postMessage"
+      | None -> [], None
     in
     match url with
     | None ->
@@ -189,18 +189,10 @@ module Slack : Api.Slack = struct
       let data = Slack_j.string_of_post_message_req msg in
       let body = `Raw ("application/json", data) in
       log#info "data: %s" data;
-      if webhook_mode then begin
-        let* _res =
-          http_request ~body ~headers `POST url |> Lwt_result.map_error (fun e -> build_error (query_error_msg url e))
-        in
-        Lwt.return @@ Ok None
-      end
-      else begin
-        let* res =
-          slack_api_request ~body ~headers `POST url Slack_j.read_post_message_res |> Lwt_result.map_error build_error
-        in
-        Lwt.return @@ Ok (Some res)
-      end
+      let* res =
+        slack_api_request ~body ~headers `POST url Slack_j.read_post_message_res |> Lwt_result.map_error build_error
+      in
+      Lwt.return @@ Ok res
 
   let send_chat_unfurl ~(ctx : Context.t) ~channel ~ts ~unfurls () =
     let req = Slack_j.{ channel; ts; unfurls } in

--- a/src/monorobot.ml
+++ b/src/monorobot.ml
@@ -74,10 +74,9 @@ let check_slack_action file secrets =
       | Error e ->
         log#error "%s" e;
         Lwt.return_unit
-      | Ok (Some res : Slack_t.post_message_res option) ->
+      | Ok (res : Slack_t.post_message_res) ->
         log#info "%s" (Slack_j.string_of_post_message_res res);
-        Lwt.return_unit
-      | Ok None -> Lwt.return_unit)
+        Lwt.return_unit)
 
 (* flags *)
 


### PR DESCRIPTION
This removes webhook mode, allowing to remove the `(_ option, _) result` for a `(_, _) result`.

I am not sure what was the point of the webhook mode, if its actually useful this should not be merged.
