### PR TITLE
Failed builds buildkite webhook

### DIFF
--- a/documentation/secret_docs.md
+++ b/documentation/secret_docs.md
@@ -24,8 +24,12 @@ A secrets file stores sensitive information. Unlike the repository configuration
 | `slack_access_token` | slack bot access token to enable message posting to the workspace | Yes | try to use webhooks defined in `slack_hooks` instead |
 | `slack_hooks` | list of channel names and their corresponding webhook endpoint | Yes | try to use token defined in `slack_access_token` instead |
 | `slack_signing_secret` | specify to verify incoming slack requests | Yes | - |
+| `buildkite_access_token` | Buildkite access token, used to query the Buildkite API for builds details | Yes | - |
+| `buildkite_signing_secret` | specify to verify incoming Buildkite webhook requests | Yes | - |
 
-Note that either `slack_access_token` or `slack_hooks` must be defined. If both are present, the bot will send notifications using webhooks.
+Note that:
+- either `slack_access_token` or `slack_hooks` must be defined. If both are present, the bot will send notifications using webhooks.
+- the failed builds notifications require the `buildkite_access_token` to work
 
 ## `repos`
 
@@ -99,3 +103,17 @@ Expected format:
 ```
 
 Refer [here](https://api.slack.com/messaging/webhooks) for obtaining a webhook for a channel.
+
+## `buildkite_access_token`
+This token is used to get informations regarding builds details and components. It's required to use the failed builds notifications feature.
+
+You also need to have one webhook configured on your pipelines with the `build.finished` scope. Configure the `buildkite_signing_secret` setting to validate the payloads if you require it.
+
+To manage your API access tokens, visit your [personal settings page](https://buildkite.com/user/api-access-tokens) where you can create or edit them.
+
+Admins can go to the [API Access Audit](https://buildkite.com/organizations/%7E/api-access-audit) page to review all tokens with access to the organization's data. You can also check each token's permissions and remove access if necessary.
+
+## `buildkite_signing_secret`
+This secret is used to [validate the payloads that Buildkite sends on the webhook](https://buildkite.com/docs/apis/webhooks#webhook-signature).
+
+Webhooks can be added and configured on your organization's [Notification Services settings page](https://buildkite.com/organizations/-/services).

--- a/lib/action.ml
+++ b/lib/action.ml
@@ -659,8 +659,10 @@ module Action (Github_api : Api.Github) (Slack_api : Api.Slack) (Buildkite_api :
               | false ->
                 let%lwt slack_user_id =
                   match n.build.state with
-                  | Failed | Canceled ->
-                    (* We only @mention the author if the build failed or was canceled *)
+                  (* | Failed | Canceled ->
+                     We only @mention the author if the build failed or was canceled.
+                     For now we don't notify for canceled builds. Can we get more value than troubles from it? *)
+                  | Failed ->
                     let email = extract_metadata_email n.build.meta_data.commit |> Option.default "" in
                     (match%lwt Slack_api.lookup_user ~ctx ~cfg ~email () with
                     | Ok (res : Slack_t.lookup_user_res) -> Lwt.return_some res.user.id

--- a/lib/action.ml
+++ b/lib/action.ml
@@ -647,15 +647,6 @@ module Action (Github_api : Api.Github) (Slack_api : Api.Slack) (Buildkite_api :
         (match should_notify with
         | false -> Lwt.return_unit
         | true ->
-          let failed_builds_channel = failed_builds_channel_exn cfg n in
-          let%lwt slack_user_id =
-            let email = extract_metadata_email n.build.meta_data.commit |> Option.default "" in
-            match%lwt Slack_api.lookup_user ~ctx ~cfg ~email () with
-            | Ok (res : Slack_t.lookup_user_res) -> Lwt.return_some res.user.id
-            | Error e ->
-              log#warn "couldn't match commit email %s to slack profile: %s" email e;
-              Lwt.return_none
-          in
           let repo_state = State.find_or_add_repo ctx.state repo_url in
           let get_build ~build_url =
             Buildkite_api.get_build' ~ctx ~build_url ~build_nr:(string_of_int n.build.number) id
@@ -663,16 +654,29 @@ module Action (Github_api : Api.Github) (Slack_api : Api.Slack) (Buildkite_api :
           (match%lwt new_failed_steps ~repo_state ~get_build n with
           | Error e -> action_error e
           | Ok failed_steps ->
-            let notifications =
-              match failed_steps with
-              | [] -> []
-              | failed_steps ->
-                let is_fix_build_notification = n.build.state = Passed in
-                let channel = Common.Status_notification.inject_channel failed_builds_channel in
-                [
-                  Slack.generate_failed_build_notification ?slack_user_id ~is_fix_build_notification ~failed_steps n
-                    channel;
-                ]
+            let%lwt notifications =
+              let channel = Common.Status_notification.inject_channel (failed_builds_channel_exn cfg n) in
+              match FailedStepSet.is_empty failed_steps with
+              | true ->
+                (match n.build.state with
+                | Passed ->
+                  Lwt.return
+                    [ Slack.generate_failed_build_notification ~is_fix_build_notification:true ~failed_steps n channel ]
+                | _ -> Lwt.return [])
+              | false ->
+                let%lwt slack_user_id =
+                  match n.build.state with
+                  | Failed | Canceled ->
+                    (* We only @mention the author if the build failed or was canceled *)
+                    let email = extract_metadata_email n.build.meta_data.commit |> Option.default "" in
+                    (match%lwt Slack_api.lookup_user ~ctx ~cfg ~email () with
+                    | Ok (res : Slack_t.lookup_user_res) -> Lwt.return_some res.user.id
+                    | Error e ->
+                      log#warn "couldn't match commit email %s to slack profile: %s" email e;
+                      Lwt.return_none)
+                  | _ -> Lwt.return_none
+                in
+                Lwt.return [ Slack.generate_failed_build_notification ?slack_user_id ~failed_steps n channel ]
             in
             let%lwt () = send_notifications ctx notifications in
             (match ctx.state_filepath with

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -50,4 +50,11 @@ module type Buildkite = sig
     ctx:Context.t ->
     Github_t.status_notification ->
     (Buildkite_t.get_build_res, string) Result.t Lwt.t
+
+  val get_build' :
+    ctx:Context.t ->
+    build_url:string ->
+    build_nr:string ->
+    (Buildkite_t.get_build_res -> 'a) ->
+    ('a, string) Result.t Lwt.t
 end

--- a/lib/api_remote.ml
+++ b/lib/api_remote.ml
@@ -330,27 +330,28 @@ module Buildkite : Api.Buildkite = struct
     let url = sprintf "organizations/%s/pipelines/%s/builds/%s/jobs/%s/log" org pipeline build_nr job.id in
     request_token_auth ~name:"get buildkite job logs" ~ctx `GET url Buildkite_j.job_log_of_string
 
-  let get_build' ~ctx ~org ~pipeline ~build_nr map =
-    let build_url = sprintf "organizations/%s/pipelines/%s/builds/%s" org pipeline build_nr in
+  let get_build' ~ctx ~build_url ~build_nr map =
     let* build = request_token_auth ~name:"get build details" ~ctx `GET build_url Buildkite_j.get_build_res_of_string in
     Builds_cache.set builds_cache build_nr build;
     Lwt.return_ok (map build)
 
   let get_build ?(cache : [ `Use | `Refresh ] = `Use) ~(ctx : Context.t) (n : Github_t.status_notification) =
     let* org, pipeline, build_nr = Lwt.return @@ Util.Build.get_org_pipeline_build n in
+    let build_url = sprintf "organizations/%s/pipelines/%s/builds/%s" org pipeline build_nr in
     match cache with
     | `Use ->
       (match Builds_cache.get builds_cache build_nr with
       | Some build -> Lwt.return_ok build
-      | None -> get_build' ~ctx ~org ~pipeline ~build_nr id)
-    | `Refresh -> get_build' ~ctx ~org ~pipeline ~build_nr id
+      | None -> get_build' ~ctx ~build_url ~build_nr id)
+    | `Refresh -> get_build' ~ctx ~build_url ~build_nr id
 
   let get_build_branch ~(ctx : Context.t) (n : Github_t.status_notification) =
     let* org, pipeline, build_nr = Lwt.return @@ Util.Build.get_org_pipeline_build n in
+    let build_url = sprintf "organizations/%s/pipelines/%s/builds/%s" org pipeline build_nr in
     let map_branch { Buildkite_t.branch; _ } : Github_t.branch = { name = branch } in
     match Builds_cache.get builds_cache build_nr with
     | Some { Buildkite_t.branch; _ } -> Lwt.return_ok ({ name = branch } : Github_t.branch)
     | None ->
       log#info "Fetching branch details for build %s in pipeline %s" build_nr pipeline;
-      get_build' ~ctx ~org ~pipeline ~build_nr map_branch
+      get_build' ~ctx ~build_url ~build_nr map_branch
 end

--- a/lib/buildkite.atd
+++ b/lib/buildkite.atd
@@ -85,8 +85,8 @@ type get_build_response = {
   (* There are more fields, but we don't need/want them for now *)
 }
 
-(* These are custom types for the steps state and not Buildkite types. We have them here
-   to avoid circular dependencies with common.atd, common.ml and state.m  *)
+(* Custom type for the steps state and not a Buildkite type. We have them here
+   to avoid circular dependencies with common.atd, common.ml and state.ml *)
 type failed_step = {
   name: string;
   build_url: string;

--- a/lib/buildkite.atd
+++ b/lib/buildkite.atd
@@ -77,17 +77,17 @@ type get_build_res = {
   branch: string;
 }
 
-(* This is a custom type for the steps state and not a Buildkite type. We have it here
-   to avoid circular dependencies with common.atd, common.ml and state.m  *)
-type failed_step = {
-  name: string;
-  build_url: string;
-}
-
 type get_build_response = {
   number: int;
   branch: string;
   jobs: job list;
   url: string;
   (* There are more fields, but we don't need/want them for now *)
+}
+
+(* These are custom types for the steps state and not Buildkite types. We have them here
+   to avoid circular dependencies with common.atd, common.ml and state.m  *)
+type failed_step = {
+  name: string;
+  build_url: string;
 }

--- a/lib/buildkite_webhook.atd
+++ b/lib/buildkite_webhook.atd
@@ -1,0 +1,48 @@
+type build_state <ocaml from="Buildkite"> = abstract
+type timestamp = string wrap <ocaml module="Common.Timestamp">
+
+(* for now we only subscribe to build.finished *)
+type webhook_event = [
+  | Build_finished <json name="build.finished">
+  | Other of string
+] <json open_enum> <ocaml repr="classic">
+
+type build_creator = {
+  email: string;
+}
+type build_metadata = {
+  commit <json name="buildkite:git:commit"> : string;
+}
+
+type build = {
+  id: string;
+  api_url <json name="url"> : string;
+  web_url: string;
+  number: int;
+  state: build_state;
+  cancel_reason: string nullable;
+  blocked: bool;
+  blocked_state: string nullable;
+  message: string;
+  sha <json name="commit"> : string;
+  branch: string;
+  meta_data: build_metadata;
+  creator: build_creator;
+  created_at: timestamp;
+  finished_at: timestamp nullable;
+}
+
+type pipeline = {
+  id: string;
+  web_url: string;
+  name: string;
+  description: string;
+  repository: string;
+  slug: string nullable;
+}
+
+type webhook_build_payload =  {
+  event: webhook_event;
+  build: build;
+  pipeline: pipeline;
+}

--- a/lib/common.atd
+++ b/lib/common.atd
@@ -14,7 +14,7 @@ type string_set =
   string list
     wrap <ocaml module="Common.StringSet">
 
-type failed_step <ocaml from="Buildkite" t="failed_step"> = abstract
+type failed_step <ocaml from="Buildkite"> = abstract
 
 type failed_step_set =
   failed_step list

--- a/lib/config.atd
+++ b/lib/config.atd
@@ -85,4 +85,6 @@ type secrets = {
   ?slack_signing_secret : string nullable;
   (* Buildkite access token, used to query Buildkite API for more information about builds *)
   ?buildkite_access_token : string nullable;
+  (* Buildkite uses this secret to sign webhook requests; provide to verify incoming Buildkite requests *)
+  ?buildkite_signing_secret : string nullable;
 }

--- a/lib/dune
+++ b/lib/dune
@@ -125,6 +125,18 @@
   (run atdgen -j -j-std %{deps})))
 
 (rule
+ (targets buildkite_webhook_t.ml buildkite_webhook_t.mli)
+ (deps buildkite_webhook.atd)
+ (action
+  (run atdgen -t %{deps})))
+
+(rule
+ (targets buildkite_webhook_j.ml buildkite_webhook_j.mli)
+ (deps buildkite_webhook.atd)
+ (action
+  (run atdgen -j -j-std %{deps})))
+
+(rule
  (target status_notifications_gen.ml)
  (deps ../db/sql/status_notifications.sql)
  (action

--- a/lib/slack.ml
+++ b/lib/slack.ml
@@ -455,6 +455,48 @@ let generate_status_notification ?slack_user_id ?failed_steps ~(job_log : (strin
     ~channel:(Status_notification.to_slack_channel channel)
     ()
 
+let generate_failed_build_notification ?slack_user_id ~is_fix_build_notification ~failed_steps (n : Util.Webhook.n)
+  channel =
+  let repo_url = Util.Build.git_ssh_to_https n.pipeline.repository in
+  let color_info = if n.build.state = Passed then "good" else "danger" in
+  let n_state =
+    match n.build.state with
+    | Passed -> "succeeded"
+    | Failed -> "failed"
+    | Canceled -> "failed (canceled)"
+    | _ -> "pending"
+  in
+  let build_desc = sprintf "Build <%s|#\u{200B}%d> %s" n.build.web_url n.build.number n_state in
+  let author_mention =
+    match slack_user_id with
+    | Some id -> sprintf "<@%s>" (Slack_user_id.project id)
+    | None -> sprintf "%s" (Util.Webhook.extract_metadata_email n.build.meta_data.commit |> Option.default "")
+  in
+  let pipeline_name = Util.Webhook.pipeline_name n in
+  let summary =
+    let commit_message = Util.first_line n.build.message in
+    let commit_url = sprintf "%s/commit/%s" repo_url n.build.sha in
+    match is_fix_build_notification with
+    | true -> sprintf "<%s|[%s]>: %s for \"%s\"" n.pipeline.web_url pipeline_name build_desc commit_message
+    | false ->
+      sprintf "<%s|[%s]>: %s for \"<%s|%s>\" %s" n.pipeline.web_url pipeline_name build_desc commit_url commit_message
+        author_mention
+  in
+  let text =
+    match is_fix_build_notification with
+    | true -> sprintf "*Commit*: `<%s|%s>` %s" n.build.web_url (git_short_sha_hash n.build.sha) author_mention
+    | false ->
+      let slack_step_link (s : Buildkite_t.failed_step) =
+        let step = Stre.drop_prefix s.name (pipeline_name ^ "/") |> String.lowercase_ascii in
+        sprintf "<%s|%s>" s.build_url step
+      in
+      sprintf "*Steps broken*: %s" (String.concat ", " (List.map slack_step_link failed_steps))
+  in
+  let attachment =
+    { empty_attachments with mrkdwn_in = Some [ "fields"; "text" ]; color = Some color_info; text = Some text }
+  in
+  make_message ~text:summary ~attachments:[ attachment ] ~channel:(Status_notification.to_slack_channel channel) ()
+
 let generate_commit_comment_notification ~slack_match_func api_commit notification channel =
   let { commit; _ } = api_commit in
   let { sender; comment; repository; _ } = notification in

--- a/lib/state.atd
+++ b/lib/state.atd
@@ -10,23 +10,9 @@ type user_id = string wrap <ocaml t="Common.Slack_user_id.t" wrap="Common.Slack_
 type channel_id = string wrap <ocaml t="Common.Slack_channel.Ident.t" wrap="Common.Slack_channel.Ident.inject" unwrap="Common.Slack_channel.Ident.project">
 type any_channel = string wrap <ocaml t="Common.Slack_channel.Any.t" wrap="Common.Slack_channel.Any.inject" unwrap="Common.Slack_channel.Any.project">
 
-type ci_commit = {
-  sha: string;
-  author: string;
-  commit_message: string;
-}
-
 type build_status = {
   status: status_state;
-  build_number: int;
-  build_url: string;
-  commit: ci_commit;
-  is_finished: bool;
-  (* TODO: remove default value once we migrated the current state over *)
-  ~is_canceled <ocaml default="false">: bool;
-  failed_steps: failed_step_set;
   created_at: timestamp;
-  finished_at: timestamp nullable;
 }
 
 (* A map from builds numbers to build statuses *)

--- a/lib/state.atd
+++ b/lib/state.atd
@@ -59,11 +59,17 @@ type slack_thread = {
 
 type slack_threads = slack_thread list map_as_object
 
+type failed_steps = {
+  steps: failed_step_set;
+  last_build: int;
+}
+
 (* The runtime state of a given GitHub repository *)
 type repo_state = {
   ~pipeline_statuses <ocaml mutable default="Common.StringMap.empty">: pipeline_statuses;
   ~pipeline_commits <ocaml mutable default="Common.StringMap.empty">: pipeline_commits;
   ~slack_threads <ocaml mutable default="Common.StringMap.empty">: slack_threads;
+  ~failed_steps <ocaml mutable default="Common.Stringtbl.empty ()">: failed_steps table_as_object;
 }
 
 (* The serializable runtime state of the bot *)

--- a/lib/state.ml
+++ b/lib/state.ml
@@ -6,7 +6,12 @@ let log = Log.from "state"
 type t = { state : State_t.state }
 
 let empty_repo_state () : State_t.repo_state =
-  { pipeline_statuses = StringMap.empty; pipeline_commits = StringMap.empty; slack_threads = StringMap.empty }
+  {
+    pipeline_statuses = StringMap.empty;
+    pipeline_commits = StringMap.empty;
+    slack_threads = StringMap.empty;
+    failed_steps = Stringtbl.empty ();
+  }
 
 let empty () : t =
   let state = State_t.{ repos = Stringtbl.empty (); bot_user_id = None } in

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -61,6 +61,25 @@ module Build = struct
     (* Gets the pipeline name from the buildkite context *)
     Re2.create_exn {|buildkite/([\w_-]+)|}
 
+  let git_ssh_re =
+    (* matches git ssh clone links *)
+    Re2.create_exn {|^git@([A-Za-z0-9.-]+):([A-Za-z0-9._-]+)\/([A-Za-z0-9._-]+)\.git$|}
+
+  let git_ssh_to_https url =
+    match Re2.find_submatches_exn git_ssh_re url with
+    | exception exn -> Exn.fail ~exn "failed to parse git ssh link %s" url
+    | [| Some _; Some url; Some user; Some repo |] -> sprintf "https://%s/%s/%s" url user repo
+    | _ -> failwith "failed to get repo details from the ssh link."
+
+  let git_ssh_to_contents_url url =
+    match Re2.find_submatches_exn git_ssh_re url with
+    | exception exn -> Exn.fail ~exn "failed to parse git ssh link %s" url
+    | [| Some _; Some "github.com"; Some user; Some repo |] ->
+      sprintf "https://api.github.com/repos/%s/%s/contents/{+path}" user repo
+    | [| Some _; Some url; Some user; Some repo |] ->
+      sprintf "https://%s/api/v3/repos/%s/%s/contents/{+path}" url user repo
+    | _ -> failwith "failed to get repo details from the ssh link."
+
   let is_pipeline_step context = Re2.matches buildkite_is_step_re context
 
   (** For now we only care about buildkite pipelines and steps. Other CI systems are not supported yet. *)
@@ -88,14 +107,16 @@ module Build = struct
     | build_number -> int_of_string build_number
     | exception _ -> failwith "failed to get build number from url"
 
-  let get_org_pipeline_build (n : Github_t.status_notification) =
-    match n.target_url with
-    | None -> Error "no build url. Is this a Buildkite notification?"
-    | Some build_url ->
+  let get_org_pipeline_build' build_url =
     match Re2.find_submatches_exn buildkite_org_pipeline_build_re build_url with
     | exception _ -> failwith (sprintf "failed to parse Buildkite build url: %s" build_url)
     | [| Some _; Some org; Some pipeline; Some build_nr |] -> Ok (org, pipeline, build_nr)
     | _ -> failwith "failed to get the build details from the notification. Is this a Buildkite notification?"
+
+  let get_org_pipeline_build (n : Github_t.status_notification) =
+    match n.target_url with
+    | None -> Error "no build url. Is this a Buildkite notification?"
+    | Some build_url -> get_org_pipeline_build' build_url
 
   let is_failed_build (n : Github_t.status_notification) =
     n.state = Failure && Re2.matches buildkite_is_failed_re (Option.default "" n.description)
@@ -403,4 +424,131 @@ module Cache (T : Cache_t) = struct
         None
       | false -> Some entry.value)
     | None -> None
+end
+
+module Webhook = struct
+  type n = Buildkite_webhook_t.webhook_build_payload
+
+  let parse_signature_header header =
+    let timestamp, signature =
+      String.split_on_char ',' header
+      |> List.fold_left
+           (fun acc part ->
+             match String.split_on_char '=' part with
+             | [ "timestamp"; timestamp ] -> Some timestamp, snd acc
+             | [ "signature"; signature ] -> fst acc, Some signature
+             | _ -> acc)
+           (None, None)
+    in
+    match timestamp, signature with
+    | Some timestamp, Some signature -> Ok (timestamp, signature)
+    | _ -> Error "missing timestamp or signature value in header"
+
+  let is_valid_signature ~secret ~timestamp ~signature body =
+    let message = sprintf "%s.%s" timestamp body in
+    let expected = Digestif.SHA256.(hmac_string ~key:secret message |> to_hex) in
+    match String.equal signature expected with
+    | true -> Ok ()
+    | false -> Error "webhook signature is not valid"
+
+  let validate_signature ?signing_key ~headers body =
+    match signing_key with
+    | None -> Ok ()
+    | Some secret ->
+    match List.assoc_opt "x-buildkite-signature" headers with
+    | None -> Error "unable to find header x-buildkite-signature"
+    | Some header ->
+    match parse_signature_header header with
+    | Error e -> Error (sprintf "invalid signature header: %s" e)
+    | Ok (timestamp, signature) -> is_valid_signature ~secret ~timestamp ~signature body
+
+  let validate_repo_url (secrets : Config_t.secrets) (n : Buildkite_webhook_t.webhook_build_payload) =
+    let repo_url = Build.git_ssh_to_https n.pipeline.repository in
+    match List.exists (fun (r : Config_t.repo_config) -> String.equal r.url repo_url) secrets.repos with
+    | true -> repo_url
+    | false -> failwith @@ Printf.sprintf "unsupported repository %s" repo_url
+
+  let get_pipeline_config (cfg : Config_t.config) pipeline_name =
+    match cfg.status_rules.allowed_pipelines with
+    | None -> None
+    | Some allowed_pipelines ->
+      List.find_opt (fun ({ name; _ } : Config_t.pipeline) -> String.equal name pipeline_name) allowed_pipelines
+
+  let pipeline_name ({ pipeline = { name; slug; _ }; _ } : n) = sprintf "buildkite/%s" (Option.default name slug)
+
+  let extract_metadata_email commit_str =
+    let lines = String.split_on_char '\n' commit_str in
+    let author_line = List.find_opt (String.starts_with ~prefix:"Author:") lines in
+    match author_line with
+    | None -> None
+    | Some line ->
+      (* Find the position of < and > and extract the email address from within them *)
+      let email_start = String.index_opt line '<' in
+      let email_end = String.index_opt line '>' in
+      (match email_start, email_end with
+      | Some start, Some end_pos -> Some (String.sub line (start + 1) (end_pos - start - 1))
+      | _ -> None)
+
+  let failed_builds_channel_exn cfg n =
+    let pipeline_name = pipeline_name n in
+    match get_pipeline_config cfg pipeline_name with
+    | Some ({ failed_builds_channel = Some channel; _ } : Config_t.pipeline) -> channel
+    | Some _ | None -> failwith (sprintf "no failed builds channel defined for pipeline %s" pipeline_name)
+
+  (** builds should be notified in the builds failed channel if:
+     -  the build is failed OR the build is canceled and notify_canceled_builds is true
+     -  the build is for the main branch
+     -  the current pipeline is in the allowed_pipelines list
+     -  a failed_builds_channel is defined for the pipeline
+  *)
+  let notify_fail (cfg : Config_t.config) (n : n) =
+    let pipeline_name = pipeline_name n in
+    let pipeline_config = get_pipeline_config cfg pipeline_name in
+    let notify_canceled_build =
+      match pipeline_config with
+      | None -> false
+      | Some ({ notify_canceled_builds; _ } : Config_t.pipeline) -> notify_canceled_builds && n.build.state = Canceled
+    in
+    let has_failed_builds_channel =
+      match pipeline_config with
+      | Some ({ failed_builds_channel = Some _channel; _ } : Config_t.pipeline) -> true
+      | Some _ | None -> false
+    in
+    let is_main_branch =
+      match cfg.main_branch_name with
+      | None -> false
+      | Some main_branch -> String.equal main_branch n.build.branch
+    in
+    (n.build.state = Failed || notify_canceled_build) && has_failed_builds_channel && is_main_branch
+
+  let notify_success (repo_state : State_t.repo_state) (repo_key : string) (n : n) =
+    n.build.state = Passed && Option.is_some (Stringtbl.find_opt repo_state.failed_steps repo_key)
+
+  let new_failed_steps ~(repo_state : State_t.repo_state) ~get_build (n : n) =
+    let* org, pipeline, build_nr = Lwt.return @@ Build.get_org_pipeline_build' n.build.web_url in
+    let repo_key = Printf.sprintf "%s/%s" org pipeline in
+    let get_failed_steps () =
+      let build_url = Printf.sprintf "organizations/%s/pipelines/%s/builds/%s" org pipeline build_nr in
+      let* (build : Buildkite_t.get_build_res) = get_build ~build_url in
+      let to_failed_step (job : Buildkite_t.job) = { Buildkite_t.name = job.name; build_url = job.web_url } in
+      Lwt.return_ok @@ (Build.filter_failed_jobs build.jobs |> List.map to_failed_step |> Common.FailedStepSet.of_list)
+    in
+    match Stringtbl.find_opt repo_state.failed_steps repo_key with
+    | Some state when n.build.number < state.last_build ->
+      (* discard notification for an earlier build *)
+      Lwt.return_ok []
+    | None ->
+      let* failed_steps = get_failed_steps () in
+      Stringtbl.replace repo_state.failed_steps repo_key { steps = failed_steps; last_build = n.build.number };
+      Lwt.return_ok (Common.FailedStepSet.elements failed_steps)
+    | Some state ->
+      let* build_faild_steps = get_failed_steps () in
+
+      (* return only the new failed steps. Keep all the failing steps in state, but keep the
+         original failed steps for the ones that intersect, instead of the new ones. *)
+      let steps_intersect = Common.FailedStepSet.inter state.steps build_faild_steps in
+      let new_failed_steps = Common.FailedStepSet.diff build_faild_steps state.steps in
+      let updated_steps = Common.FailedStepSet.union steps_intersect new_failed_steps in
+      Stringtbl.replace repo_state.failed_steps repo_key { steps = updated_steps; last_build = n.build.number };
+      Lwt.return_ok (Common.FailedStepSet.elements new_failed_steps)
 end

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -127,9 +127,6 @@ module Build = struct
   let is_canceled_build (n : Github_t.status_notification) =
     n.state = Failure && Re2.matches buildkite_is_canceled_re (Option.default "" n.description)
 
-  let is_success_build (n : Github_t.status_notification) =
-    n.state = Success && Re2.matches buildkite_is_success_re (Option.default "" n.description)
-
   let is_main_branch (cfg : Config_t.config) (n : Github_t.status_notification) =
     match cfg.main_branch_name with
     | None -> false
@@ -140,20 +137,6 @@ module Build = struct
     | None -> None
     | Some allowed_pipelines ->
       List.find_opt (fun ({ name; _ } : Config_t.pipeline) -> name = n.context) allowed_pipelines
-
-  let in_allowed_pipeline (cfg : Config_t.config) (n : Github_t.status_notification) =
-    match cfg.status_rules.allowed_pipelines with
-    | None -> false
-    | Some allowed_pipelines ->
-      List.exists (fun ({ name; _ } : Config_t.pipeline) -> Stre.starts_with n.context name) allowed_pipelines
-
-  let get_failed_builds_channel (cfg : Config_t.config) (n : Github_t.status_notification) =
-    match get_pipeline_config cfg n with
-    | Some ({ failed_builds_channel = Some failed_builds_channel; _ } : Config_t.pipeline) -> Some failed_builds_channel
-    | Some _ | None -> None
-
-  let has_failed_builds_channel (cfg : Config_t.config) (n : Github_t.status_notification) =
-    Option.is_some (get_failed_builds_channel cfg n)
 
   let get_branch_builds (n : Github_t.status_notification) (repo_state : State_t.repo_state) =
     match n.branches, parse_context ~context:n.context with
@@ -182,180 +165,6 @@ module Build = struct
       let n = get_build_number_exn ~build_url in
       IntMap.find_opt n builds_maps
     | _ -> None
-
-  let new_failed_steps ~get_build (n : Github_t.status_notification) (repo_state : State_t.repo_state) =
-    let log = Log.from "new_failed_steps" in
-    match n.target_url, get_branch_builds n repo_state with
-    | None, _ | _, None ->
-      (* if we don't have a target_url value, we don't have a build number and cant't track build state *)
-      Lwt.return []
-    | Some build_url, Some builds_maps ->
-    match is_failed_build n || is_canceled_build n with
-    | false -> failwith (sprintf "can't calculate failed steps: build %s is not failed or canceled" build_url)
-    | true ->
-      let current_build_number = get_build_number_exn ~build_url in
-      let previous_failed_steps =
-        IntMap.fold
-          (fun build_number (build_status : State_t.build_status) acc ->
-            match build_number >= current_build_number with
-            | true -> acc
-            | false -> FailedStepSet.union build_status.failed_steps acc)
-          builds_maps FailedStepSet.empty
-      in
-      let%lwt failed_steps =
-        let get_failed_steps_from_buildkite () =
-          log#info "getting failed steps from buildkite for %s" build_url;
-          match%lwt get_build ?cache:(Some `Refresh) n with
-          | Error e ->
-            log#error "failed to get build %s from buildkite API: %s" build_url e;
-            Lwt.return @@ FailedStepSet.empty
-          | Ok (build : Buildkite_t.get_build_res) ->
-          match build.state with
-          | Failed | Canceled ->
-            (* if we get here, we know we can use parse_context_exn *)
-            let { pipeline_name; _ } = parse_context_exn ~context:n.context in
-            let failed_steps =
-              FailedStepSet.of_list
-              @@ List.filter_map
-                   (fun (job : Buildkite_t.job_type) ->
-                     match job with
-                     | Manual _ | Waiter _ -> None
-                     | Script { name; state; web_url; _ } | Trigger { name; state; web_url; _ } ->
-                     match state with
-                     | Failed ->
-                       let name =
-                         (* replace spaces and underscores with dashes, like buildkite does *)
-                         String.map
-                           (function
-                             | ' ' | '_' -> '-'
-                             | c -> c)
-                           (String.lowercase_ascii name)
-                       in
-                       Some
-                         {
-                           Buildkite_t.build_url = web_url;
-                           name =
-                             (* mimic notification context structure so that steps can match with the existing ones *)
-                             sprintf "buildkite/%s/%s" pipeline_name name;
-                         }
-                     | _ -> None)
-                   build.jobs
-            in
-            (* we may not have this build in state, so we need to create one in that case.
-               We need to have a little bit of duplication with state.ml to avoid circular dependencies *)
-            let init_build_state =
-              {
-                State_t.status = n.state;
-                build_number = current_build_number;
-                build_url;
-                commit =
-                  { sha = n.sha; author = n.commit.commit.author.email; commit_message = n.commit.commit.message };
-                is_finished = true;
-                is_canceled = build.state = Canceled;
-                failed_steps;
-                created_at = Timestamp.wrap build.created_at;
-                finished_at = Option.map Timestamp.wrap build.finished_at;
-              }
-            in
-            let update_build_status builds_map =
-              let%lwt updated_status =
-                match IntMap.find_opt current_build_number builds_map with
-                | Some (current_build_status : State_t.build_status) ->
-                  let updated_build_status = { current_build_status with failed_steps } in
-                  Lwt.return updated_build_status
-                | None -> Lwt.return init_build_state
-              in
-              Lwt.return @@ IntMap.add current_build_number updated_status builds_map
-            in
-            let update_pipeline_status branches_statuses =
-              let init_branch_state = Lwt.return @@ IntMap.singleton current_build_number init_build_state in
-              let current_statuses = Option.default StringMap.empty branches_statuses in
-              let updated_statuses =
-                List.map
-                  (fun (branch : Github_t.branch) ->
-                    let builds_map =
-                      Option.map_default
-                        (fun branches_statuses ->
-                          match StringMap.find_opt branch.name branches_statuses with
-                          | Some builds_map -> update_build_status builds_map
-                          | None -> init_branch_state)
-                        init_branch_state branches_statuses
-                    in
-                    branch.name, builds_map)
-                  n.branches
-              in
-              let%lwt updated =
-                Lwt_list.fold_left_s
-                  (fun m (key, data) ->
-                    let%lwt v = data in
-                    Lwt.return @@ StringMap.add key v m)
-                  current_statuses updated_statuses
-              in
-              Lwt.return_some updated
-            in
-            (* we need to update the state with the failed steps, otherwise we can't calculate
-               the new failed steps in future builds *)
-            let%lwt updated_statuses =
-              StringMap.update_async pipeline_name update_pipeline_status repo_state.pipeline_statuses
-            in
-            let%lwt (_ : int64 Database.db_use_result) =
-              Database.Status_notifications_table.update_state n ~before:repo_state.pipeline_statuses
-                ~after:updated_statuses ~pipeline_name "Util.Build.new_failed_steps > update_pipeline_status"
-            in
-            repo_state.pipeline_statuses <- updated_statuses;
-            Lwt.return failed_steps
-          | _ ->
-            log#warn "build state for %s is not failed in buildkite. We will not calculate failed steps" build_url;
-            Lwt.return @@ FailedStepSet.empty
-        in
-        (* if the current build isn't in state, or doesn't have any failed steps in state, it might be that
-           we didn't get all the notifications, or that the step notifications might arrive after the build
-           failed notification. We need to get the build from the api and parse it to get the failed steps *)
-        match get_current_build n repo_state with
-        | Some b when not @@ FailedStepSet.is_empty b.failed_steps -> Lwt.return b.failed_steps
-        | Some _ -> get_failed_steps_from_buildkite ()
-        | None ->
-          log#warn "failed to find build %s in state, maybe it was cleaned up?" build_url;
-          get_failed_steps_from_buildkite ()
-      in
-      Lwt.return @@ FailedStepSet.(diff failed_steps previous_failed_steps |> elements)
-
-  let previous_build_is_failed (n : Github_t.status_notification) (repo_state : State_t.repo_state) =
-    match n.target_url with
-    | None -> failwith "no build url. Is this a Buildkite notification?"
-    | Some build_url ->
-    match get_branch_builds n repo_state with
-    | None -> false
-    | Some build_statuses ->
-      let current_build_number = get_build_number_exn ~build_url in
-      let previous_builds =
-        IntMap.filter
-          (fun build_num ({ is_finished; is_canceled; _ } : State_t.build_status) ->
-            (* we don't take canceled builds into account, since they didn't run to completion *)
-            is_finished && (not is_canceled) && build_num < current_build_number)
-          build_statuses
-      in
-      (match IntMap.is_empty previous_builds with
-      | true ->
-        (* if we find no previous builds, it means they were successful and cleaned from state *)
-        false
-      | false ->
-        let latest_build = previous_builds |> IntMap.max_binding |> snd in
-        latest_build.status = Failure)
-
-  (* builds should be notified in the builds failed channel if:
-     -  the build is failed OR the build is canceled and notify_canceled_builds is true
-     -  the build is for the main branch
-     -  the pipeline is in the allowed_pipelines list
-     -  a failed_builds_channel is defined for the pipeline
-  *)
-  let notify_fail (n : Github_t.status_notification) (cfg : Config_t.config) =
-    let notify_canceled_build =
-      match get_pipeline_config cfg n with
-      | None -> false
-      | Some ({ notify_canceled_builds; _ } : Config_t.pipeline) -> notify_canceled_builds && is_canceled_build n
-    in
-    (is_failed_build n || notify_canceled_build) && has_failed_builds_channel cfg n && is_main_branch cfg n
 
   let stale_build_threshold =
     (* 2h as the threshold for long running or stale builds *)
@@ -476,6 +285,8 @@ module Webhook = struct
 
   let pipeline_name ({ pipeline = { name; slug; _ }; _ } : n) = sprintf "buildkite/%s" (Option.default name slug)
 
+  let repo_key org pipeline = Printf.sprintf "%s/%s" org pipeline
+
   let extract_metadata_email commit_str =
     let lines = String.split_on_char '\n' commit_str in
     let author_line = List.find_opt (String.starts_with ~prefix:"Author:") lines in
@@ -526,7 +337,7 @@ module Webhook = struct
 
   let new_failed_steps ~(repo_state : State_t.repo_state) ~get_build (n : n) =
     let* org, pipeline, build_nr = Lwt.return @@ Build.get_org_pipeline_build' n.build.web_url in
-    let repo_key = Printf.sprintf "%s/%s" org pipeline in
+    let repo_key = repo_key org pipeline in
     let get_failed_steps () =
       let build_url = Printf.sprintf "organizations/%s/pipelines/%s/builds/%s" org pipeline build_nr in
       let* (build : Buildkite_t.get_build_res) = get_build ~build_url in

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -316,7 +316,8 @@ module Webhook = struct
   let notify_fail (cfg : Config_t.config) (n : n) =
     let pipeline_name = pipeline_name n in
     let pipeline_config = get_pipeline_config cfg pipeline_name in
-    let notify_canceled_build =
+    (* For now we don't notify for canceled builds. Can we get more value than troubles from it? *)
+    let _notify_canceled_build =
       match pipeline_config with
       | None -> false
       | Some ({ notify_canceled_builds; _ } : Config_t.pipeline) -> notify_canceled_builds && n.build.state = Canceled
@@ -331,7 +332,7 @@ module Webhook = struct
       | None -> false
       | Some main_branch -> String.equal main_branch n.build.branch
     in
-    (n.build.state = Failed || notify_canceled_build) && has_failed_builds_channel && is_main_branch
+    n.build.state = Failed && has_failed_builds_channel && is_main_branch
 
   let notify_success (repo_state : State_t.repo_state) (repo_key : string) (n : n) =
     n.build.state = Passed

--- a/src/request_handler.ml
+++ b/src/request_handler.ml
@@ -41,6 +41,10 @@ let run ~ctx ~addr ~port =
             log#debug "slack event: %s" request.body;
             let%lwt res = Action.process_slack_event ctx request.headers request.body in
             ret res
+          | _, [ "bk_webhook" ] ->
+            log#debug "buildkite webhook: %s" request.body;
+            let%lwt () = Action.process_buildkite_webhook ctx request.headers request.body in
+            ret "ok"
           | _, _ ->
             log#error "unknown path : %s" (Httpev.show_request request);
             ret_err `Not_found "not found"

--- a/test/slack_payloads.expected
+++ b/test/slack_payloads.expected
@@ -526,50 +526,8 @@ will notify #longest-a1
   "unfurl_links": false
 }
 ===== file ../mock_payloads/status.canceled_diff_failed_jobs.json =====
-will notify #failed-builds
-{
-  "channel": "failed-builds",
-  "text": "<https://buildkite.com/org/pipeline2|[buildkite/pipeline2]>: Build <https://buildkite.com/org/pipeline2/builds/181734|#​181734> canceled by author (7 minutes, 29 seconds) for \"<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|c1 message>\" <@id[author@ahrefs.com]>",
-  "attachments": [
-    {
-      "fallback": null,
-      "mrkdwn_in": [ "fields", "text" ],
-      "color": "danger",
-      "text": "*Steps broken*: <https://buildkite.com/org/pipeline2/builds/181734#01948e8b-5b5e-4e4a-9e0b-b8b64e381c90|test>"
-    }
-  ],
-  "unfurl_links": false
-}
 ===== file ../mock_payloads/status.canceled_empty_failed_jobs.json =====
-will notify #failed-builds
-{
-  "channel": "failed-builds",
-  "text": "<https://buildkite.com/org/pipeline2|[buildkite/pipeline2]>: Build <https://buildkite.com/org/pipeline2/builds/181734|#​181734> canceled by author (7 minutes, 29 seconds) for \"<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|c1 message>\" <@id[author@ahrefs.com]>",
-  "attachments": [
-    {
-      "fallback": null,
-      "mrkdwn_in": [ "fields", "text" ],
-      "color": "danger",
-      "text": "*Steps broken*: <https://buildkite.com/org/pipeline2/builds/181734#01948e8b-5b5f-44e0-ae9b-0b6f33f48ac8|fail>, <https://buildkite.com/org/pipeline2/builds/181734#01948e8b-5b5e-4e4a-9e0b-b8b64e381c90|test>, <https://buildkite.com/org/pipeline2/builds/181734#01948e8b-5b85-4bd7-bfe0-769f4fbbb03f|trigger-infra>"
-    }
-  ],
-  "unfurl_links": false
-}
 ===== file ../mock_payloads/status.canceled_no_build_state.json =====
-will notify #failed-builds
-{
-  "channel": "failed-builds",
-  "text": "<https://buildkite.com/org/pipeline2|[buildkite/pipeline2]>: Build <https://buildkite.com/org/pipeline2/builds/181734|#​181734> canceled by author (7 minutes, 29 seconds) for \"<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|c1 message>\" <@id[author@ahrefs.com]>",
-  "attachments": [
-    {
-      "fallback": null,
-      "mrkdwn_in": [ "fields", "text" ],
-      "color": "danger",
-      "text": "*Steps broken*: <https://buildkite.com/org/pipeline2/builds/181734#01948e8b-5b5f-44e0-ae9b-0b6f33f48ac8|fail>, <https://buildkite.com/org/pipeline2/builds/181734#01948e8b-5b5e-4e4a-9e0b-b8b64e381c90|test>, <https://buildkite.com/org/pipeline2/builds/181734#01948e8b-5b85-4bd7-bfe0-769f4fbbb03f|trigger-infra>"
-    }
-  ],
-  "unfurl_links": false
-}
 ===== file ../mock_payloads/status.canceled_test.json =====
 ===== file ../mock_payloads/status.commit1-01-failing.json =====
 will notify #default
@@ -581,7 +539,7 @@ will notify #default
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` \n*Branch*: author/patches/js-storage"
+      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: author/patches/js-storage"
     }
   ],
   "unfurl_links": false
@@ -595,7 +553,7 @@ will notify #id[author@ahrefs.com]
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` \n*Branch*: author/patches/js-storage"
+      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: author/patches/js-storage"
     }
   ],
   "unfurl_links": false
@@ -630,7 +588,7 @@ will notify #default
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` <@id[author@ahrefs.com]>\n*Branch*: author/patches/js-storage"
+      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: author/patches/js-storage"
     }
   ],
   "unfurl_links": false
@@ -645,7 +603,7 @@ will notify #default
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` <@id[author@ahrefs.com]>\n*Branch*: author/patches/js-storage"
+      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: author/patches/js-storage"
     }
   ],
   "unfurl_links": false
@@ -660,21 +618,7 @@ will notify #all-push-events
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` <@id[author@ahrefs.com]>\n*Branch*: develop"
-    }
-  ],
-  "unfurl_links": false
-}
-will notify #failed-builds
-{
-  "channel": "failed-builds",
-  "text": "<https://buildkite.com/org/pipeline2|[buildkite/pipeline2]>: Build <https://buildkite.com/org/pipeline2/builds/181732|#​181732> failed (7 minutes, 29 seconds) for \"<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|c1 message>\" <@id[author@ahrefs.com]>",
-  "attachments": [
-    {
-      "fallback": null,
-      "mrkdwn_in": [ "fields", "text" ],
-      "color": "danger",
-      "text": "*Steps broken*: <https://buildkite.com/org/pipeline2/builds/181732#0192347d-e4ee-4072-9da4-f441eeb65ed4|pipeline2/failed-step>"
+      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: develop"
     }
   ],
   "unfurl_links": false
@@ -689,37 +633,37 @@ will notify #default
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` <@id[author@ahrefs.com]>\n*Branch*: author/patches/js-storage"
+      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: author/patches/js-storage"
     }
   ],
   "unfurl_links": false
 }
 ===== file ../mock_payloads/status.failed_diff_failed_jobs.json =====
-will notify #failed-builds
+will notify #all-push-events
 {
-  "channel": "failed-builds",
-  "text": "<https://buildkite.com/org/pipeline2|[buildkite/pipeline2]>: Build <https://buildkite.com/org/pipeline2/builds/181734|#​181734> failed (7 minutes, 29 seconds) for \"<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|c1 message>\" <@id[author@ahrefs.com]>",
+  "channel": "all-push-events",
+  "text": "<https://buildkite.com/org/pipeline2|[buildkite/pipeline2]>: Build <https://buildkite.com/org/pipeline2/builds/181734|#​181734> failed (7 minutes, 29 seconds) for \"c1 message\"",
   "attachments": [
     {
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Steps broken*: <https://buildkite.com/org/pipeline2/builds/181734#01948e8b-5b5e-4e4a-9e0b-b8b64e381c90|test>"
+      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: develop"
     }
   ],
   "unfurl_links": false
 }
 ===== file ../mock_payloads/status.failed_empty_failed_jobs.json =====
-will notify #failed-builds
+will notify #all-push-events
 {
-  "channel": "failed-builds",
-  "text": "<https://buildkite.com/org/pipeline2|[buildkite/pipeline2]>: Build <https://buildkite.com/org/pipeline2/builds/181734|#​181734> failed (7 minutes, 29 seconds) for \"<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|c1 message>\" <@id[author@ahrefs.com]>",
+  "channel": "all-push-events",
+  "text": "<https://buildkite.com/org/pipeline2|[buildkite/pipeline2]>: Build <https://buildkite.com/org/pipeline2/builds/181734|#​181734> failed (7 minutes, 29 seconds) for \"c1 message\"",
   "attachments": [
     {
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Steps broken*: <https://buildkite.com/org/pipeline2/builds/181734#01948e8b-5b5f-44e0-ae9b-0b6f33f48ac8|fail>, <https://buildkite.com/org/pipeline2/builds/181734#01948e8b-5b5e-4e4a-9e0b-b8b64e381c90|test>, <https://buildkite.com/org/pipeline2/builds/181734#01948e8b-5b85-4bd7-bfe0-769f4fbbb03f|trigger-infra>"
+      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: develop"
     }
   ],
   "unfurl_links": false
@@ -734,27 +678,41 @@ will notify #default
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` <@id[author@ahrefs.com]>\n*Branch*: other-branch"
+      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: other-branch"
     }
   ],
   "unfurl_links": false
 }
 ===== file ../mock_payloads/status.failed_no_build_state.json =====
-will notify #failed-builds
+will notify #all-push-events
 {
-  "channel": "failed-builds",
-  "text": "<https://buildkite.com/org/pipeline2|[buildkite/pipeline2]>: Build <https://buildkite.com/org/pipeline2/builds/181734|#​181734> failed (7 minutes, 29 seconds) for \"<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|c1 message>\" <@id[author@ahrefs.com]>",
+  "channel": "all-push-events",
+  "text": "<https://buildkite.com/org/pipeline2|[buildkite/pipeline2]>: Build <https://buildkite.com/org/pipeline2/builds/181734|#​181734> failed (7 minutes, 29 seconds) for \"c1 message\"",
   "attachments": [
     {
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Steps broken*: <https://buildkite.com/org/pipeline2/builds/181734#01948e8b-5b5f-44e0-ae9b-0b6f33f48ac8|fail>, <https://buildkite.com/org/pipeline2/builds/181734#01948e8b-5b5e-4e4a-9e0b-b8b64e381c90|test>, <https://buildkite.com/org/pipeline2/builds/181734#01948e8b-5b85-4bd7-bfe0-769f4fbbb03f|trigger-infra>"
+      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: develop"
     }
   ],
   "unfurl_links": false
 }
 ===== file ../mock_payloads/status.failure_test.json =====
+will notify #default
+{
+  "channel": "default",
+  "text": "<https://buildkite.com/org/pipeline2|[buildkite/pipeline2]>: Build <https://buildkite.com/org/pipeline2/builds/2|#​2> failed (20 seconds) for \"Update README.md\"",
+  "attachments": [
+    {
+      "fallback": null,
+      "mrkdwn_in": [ "fields", "text" ],
+      "color": "danger",
+      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/0d95302addd66c1816bce1b1d495ed1c93ccd478|0d95302a>` Khady\n*Branch*: master"
+    }
+  ],
+  "unfurl_links": false
+}
 ===== file ../mock_payloads/status.failure_test_main_branch.json =====
 will notify #all-push-events
 {
@@ -765,21 +723,7 @@ will notify #all-push-events
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/0d95302addd66c1816bce1b1d495ed1c93ccd478|0d95302a>` <@id[slack_mail@example.com]>\n*Branch*: develop"
-    }
-  ],
-  "unfurl_links": false
-}
-will notify #failed-builds
-{
-  "channel": "failed-builds",
-  "text": "<https://buildkite.com/org/pipeline2|[buildkite/pipeline2]>: Build <https://buildkite.com/org/pipeline2/builds/2|#​2> failed (20 seconds) for \"<https://github.com/ahrefs/monorepo/commit/0d95302addd66c1816bce1b1d495ed1c93ccd478|Update README.md>\" <@id[slack_mail@example.com]>",
-  "attachments": [
-    {
-      "fallback": null,
-      "mrkdwn_in": [ "fields", "text" ],
-      "color": "danger",
-      "text": "*Steps broken*: <https://buildkite.com/org/pipeline2/builds/2#0192347d-e4ee-4072-9da4-f441eeb65ed4|pipeline2/failed-step>"
+      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/0d95302addd66c1816bce1b1d495ed1c93ccd478|0d95302a>` Khady\n*Branch*: develop"
     }
   ],
   "unfurl_links": false
@@ -794,7 +738,7 @@ will notify #default
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/0d95302addd66c1816bce1b1d495ed1c93ccd478|0d95302a>` <@id[slack_mail@example.com]>\n*Branch*: master"
+      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/0d95302addd66c1816bce1b1d495ed1c93ccd478|0d95302a>` Khady\n*Branch*: master"
     }
   ],
   "unfurl_links": false
@@ -805,34 +749,6 @@ will notify #default
 ===== file ../mock_payloads/status.state_hide_success_test.json =====
 ===== file ../mock_payloads/status.state_hide_success_test_disallowed_pipeline.json =====
 ===== file ../mock_payloads/status.success_fix_failed_builds.json =====
-will notify #all-push-events
-{
-  "channel": "all-push-events",
-  "text": "<https://buildkite.com/org/pipeline2|[buildkite/pipeline2]>: Build <https://buildkite.com/org/pipeline2/builds/3|#​3> passed (5 minutes, 19 seconds) for \"Update README.md\"",
-  "attachments": [
-    {
-      "fallback": null,
-      "mrkdwn_in": [ "fields", "text" ],
-      "color": "good",
-      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/0d95302addd66c1816bce1b1d495ed1c93ccd478|0d95302a>` \n*Branch*: develop"
-    }
-  ],
-  "unfurl_links": false
-}
-will notify #failed-builds
-{
-  "channel": "failed-builds",
-  "text": "<https://buildkite.com/org/pipeline2|[buildkite/pipeline2]>: Build <https://buildkite.com/org/pipeline2/builds/3|#​3> passed (5 minutes, 19 seconds) for \"Update README.md\"",
-  "attachments": [
-    {
-      "fallback": null,
-      "mrkdwn_in": [ "fields", "text" ],
-      "color": "good",
-      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/0d95302addd66c1816bce1b1d495ed1c93ccd478|0d95302a>` "
-    }
-  ],
-  "unfurl_links": false
-}
 ===== file ../mock_payloads/status.success_no_previous_builds.json =====
 ===== file ../mock_payloads/status.success_public_repo_no_buildkite.json =====
 will notify #default
@@ -844,7 +760,7 @@ will notify #default
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "good",
-      "text": "*Commit*: `<https://github.com/Codertocat/Hello-World/commit/6113728f27ae82c7b1a177c8d03f9e96e0adf246|6113728f>` \n*Branches*: master, changes, gh-pages"
+      "text": "*Commit*: `<https://github.com/Codertocat/Hello-World/commit/6113728f27ae82c7b1a177c8d03f9e96e0adf246|6113728f>` Codertocat\n*Branches*: master, changes, gh-pages"
     }
   ],
   "unfurl_links": false


### PR DESCRIPTION
Given that the current setup with GHE webhook on BK app is unreliable due to unexpected and unexplained issues with the notifications plus the bad documentation and lack of it too, this PR changes the architecture and approach to depend only on a BK webhook listening to `build:failed` events.

Flow is:
- receive the request from bk
- parse it and get more details on the build calling the API
- filter out failed jobs
- generate notifications and notify

This new architecture completely separates failed builds logic from the existing logic for status notifications, which simplifies and cleans up the process. The way we handle state was also changed to a structure that conforms more with the nature of the distributed build system and possible race conditions.

Hopefully this approach will ensure that we don't miss the updates and can react to the state of the CI.

For now I have also removed canceled builds support. Previously they were supported due to the architecture allowing us to follow the progress of the builds with per-step notifications. Currently we can't do that, so we would not be able to add value when supporting canceled builds. If we find the buildkite webhooks reliable, and we need to support canceled builds, we can subscribe to the per-step webhook and support canceled builds in the future.

I have also removed the debug db integration with the existing notifications flow. I didn't add it to the new one to avoid introducing more complexity and code to review on this PR. I will add it back to a following PR.