### PR TITLE
add a missing case in escaping

### DIFF
--- a/lib/text_cleanup/lexer.mll
+++ b/lib/text_cleanup/lexer.mll
@@ -8,9 +8,12 @@ let timestamp = esc "_bk;t=" digit* '\007'
 
 let color_code = esc '[' (digit | ';') * ['a'-'z' 'A'-'Z']
 
-let to_delete = timestamp | color_code
+let cursor_show_hide = esc "[?25" ('l' | 'h')
+
+let to_delete = timestamp | color_code | cursor_show_hide
 
 rule cleanup buf = parse
 | to_delete { cleanup buf lexbuf }
+| esc { Buffer.add_string buf "\\027"; cleanup buf lexbuf }
 | _ { Buffer.add_string buf (Lexing.lexeme lexbuf); cleanup buf lexbuf }
 | eof { () }

--- a/lib/text_cleanup/test/job_log.t/log3
+++ b/lib/text_cleanup/test/job_log.t/log3
@@ -1,0 +1,7 @@
+
+[?25lInstalling to existing venv 'something'
+
+
+[?25h[09:52:01 #] sudo aptitude install -y package1 package2
+
+

--- a/lib/text_cleanup/test/job_log.t/run.t
+++ b/lib/text_cleanup/test/job_log.t/run.t
@@ -452,3 +452,12 @@
   user command error: exit status 1
   
   "
+  $ dune exec text_cleanup -- log3 | sed 's/\$/%/g' | sed 's/\\n/\n/g'
+  "
+  Installing to existing venv 'something'
+  
+  
+  [09:52:01 #] sudo aptitude install -y package1 package2
+  
+  \\027
+  "


### PR DESCRIPTION
There was some missing case in escaping

I also added more systematic escaping. Any time a `"\027"` character is seen, it is replaced by `"\\027" which is not going to prevent slack from showing a preview.

As far as I know, terminal escape sequences start with with `"\027"` so this should be enough for most of them.  
