### PR TITLE
10 lines of failure log are disaplayed in the error DMmessage

### DIFF
--- a/lib/slack.ml
+++ b/lib/slack.ml
@@ -380,18 +380,12 @@ let generate_status_notification ~(job_log : (string * string) list) ~(cfg : Con
       in
       [ sprintf "*%s*: %s" (pluralize ~suf:"es" ~len:(List.length branches) "Branch") (String.concat ", " branches) ]
   in
-  let job_log_lines =
-    let lines =
+  let job_log_lines ~n =
       job_log
       |> List.map (fun (job_name, job_log) ->
-             (* Buildkite has different "sections" on their builds logs. The commands we run come only after this line. *)
-             let text = job_log |> Text_cleanup.cleanup |> String.split_on_char '\n' |> List.rev |> List.to_seq in
-             job_name, text)
-    in
-    fun ~n ->
-      lines
-      |> List.map (fun (job_name, lines) ->
+             let lines = job_log |> Text_cleanup.cleanup |> String.split_on_char '\n' |> List.rev |> List.to_seq in
              let text = lines |> Seq.take n |> List.of_seq |> List.rev |> String.concat "\n" in
+             (* Buildkite has different "sections" on their builds logs. The commands we run come only after this line. *)
              let after_cmd = Stre.after text "~~~ Running commands\n" |> String.trim in
              let text = if after_cmd <> "" then after_cmd else text in
              job_name, text)

--- a/lib/slack.ml
+++ b/lib/slack.ml
@@ -380,6 +380,30 @@ let generate_status_notification ~(job_log : (string * string) list) ~(cfg : Con
       in
       [ sprintf "*%s*: %s" (pluralize ~suf:"es" ~len:(List.length branches) "Branch") (String.concat ", " branches) ]
   in
+  let job_log_lines =
+    let lines =
+      job_log
+      |> List.map (fun (job_name, job_log) ->
+             (* Buildkite has different "sections" on their builds logs. The commands we run come only after this line. *)
+             let text = job_log |> Text_cleanup.cleanup |> String.split_on_char '\n' |> List.rev |> List.to_seq in
+             job_name, text)
+    in
+    fun ~n ->
+      lines
+      |> List.map (fun (job_name, lines) ->
+             let text = lines |> Seq.take n |> List.of_seq |> List.rev |> String.concat "\n" in
+             let after_cmd = Stre.after text "~~~ Running commands\n" |> String.trim in
+             let text = if after_cmd <> "" then after_cmd else text in
+             job_name, text)
+  in
+  let job_log_peek =
+    job_log_lines ~n:10
+    |> (function
+         | [] -> None
+         | (job_log, content) :: _ -> Some (job_log, content))
+    |> Option.map (fun (job_log, content) -> sprintf "*%s*\n```%s```" job_log content)
+    |> Stdlib.Option.to_list
+  in
   let summary =
     let state_info =
       match state with
@@ -412,7 +436,7 @@ let generate_status_notification ~(job_log : (string * string) list) ~(cfg : Con
         | None -> default_summary
         | Some pipeline_url -> sprintf "<%s|[%s]>: %s for \"%s\"" pipeline_url context build_desc commit_message)
   in
-  let text = Some (String.concat "\n" @@ List.concat [ commit_info; branches_info ]) in
+  let text = Some (String.concat "\n" @@ List.concat [ commit_info; branches_info; job_log_peek ]) in
   let attachment = { empty_attachments with mrkdwn_in = Some [ "fields"; "text" ]; color = Some color_info; text } in
   let handler =
     match job_log with
@@ -422,24 +446,9 @@ let generate_status_notification ~(job_log : (string * string) list) ~(cfg : Con
     | _ :: _ when Status_notification.is_user channel ->
       log#info "failed jobs logs are going to be sent";
       let files =
-        job_log
-        |> List.map (fun (job_name, job_log) ->
-               let clean =
-                 job_log
-                 |> Text_cleanup.cleanup
-                 |> String.split_on_char '\n'
-                 |> List.rev
-                 |> List.to_seq
-                 |> Seq.take 200
-                 |> List.of_seq
-                 |> List.rev
-                 |> String.concat "\n"
-               in
-               (* Buildkite has different "sections" on their builds logs. The commands we run come only after this line. *)
-               let content = Stre.after clean "~~~ Running commands\n" |> String.trim in
-               let content = if content <> "" then content else clean in
-               { name = job_name; title = None; alt_txt = None; content })
+        job_log_lines ~n:100 |> List.map (fun (name, content) -> { name; title = None; alt_txt = None; content })
       in
+
       Some
         (fun (send_file : file:file_req -> (unit, string) result Lwt.t) (res : Slack_t.post_message_res) ->
           let ({ ts; channel; _ } : post_message_res) = res in

--- a/lib/slack.ml
+++ b/lib/slack.ml
@@ -381,20 +381,19 @@ let generate_status_notification ~(job_log : (string * string) list) ~(cfg : Con
       [ sprintf "*%s*: %s" (pluralize ~suf:"es" ~len:(List.length branches) "Branch") (String.concat ", " branches) ]
   in
   let job_log_lines ~n =
-      job_log
-      |> List.map (fun (job_name, job_log) ->
-             let lines = job_log |> Text_cleanup.cleanup |> String.split_on_char '\n' |> List.rev |> List.to_seq in
-             let text = lines |> Seq.take n |> List.of_seq |> List.rev |> String.concat "\n" in
-             (* Buildkite has different "sections" on their builds logs. The commands we run come only after this line. *)
-             let after_cmd = Stre.after text "~~~ Running commands\n" |> String.trim in
-             let text = if after_cmd <> "" then after_cmd else text in
-             job_name, text)
+    job_log
+    |> List.map (fun (job_name, job_log) ->
+           let lines = job_log |> Text_cleanup.cleanup |> String.split_on_char '\n' |> List.rev |> List.to_seq in
+           let text = lines |> Seq.take n |> List.of_seq |> List.rev |> String.concat "\n" in
+           (* Buildkite has different "sections" on their builds logs. The commands we run come only after this line. *)
+           let after_cmd = Stre.after text "~~~ Running commands\n" |> String.trim in
+           let text = if after_cmd <> "" then after_cmd else text in
+           job_name, text)
   in
-  let job_log_peek =
-    job_log_lines ~n:10
-    |> (function
-         | [] -> None
-         | (job_log, content) :: _ -> Some ([{ title = Some job_log; value = sprintf "```%s```" content; short = false }]))
+  let fields =
+    job_log_lines ~n:10 |> function
+    | [] -> None
+    | (job_log, content) :: _ -> Some [ { title = Some job_log; value = sprintf "```%s```" content; short = false } ]
   in
   let summary =
     let state_info =
@@ -430,13 +429,7 @@ let generate_status_notification ~(job_log : (string * string) list) ~(cfg : Con
   in
   let text = Some (String.concat "\n" @@ List.concat [ commit_info; branches_info ]) in
   let attachment =
-    {
-      empty_attachments with
-      mrkdwn_in = Some [ "fields"; "text" ];
-      color = Some color_info;
-      text;
-      fields = Option.map (fun a -> [ a ]) job_log_peek;
-    }
+    { empty_attachments with mrkdwn_in = Some [ "fields"; "text" ]; color = Some color_info; text; fields }
   in
   let handler =
     match job_log with

--- a/lib/slack.ml
+++ b/lib/slack.ml
@@ -400,9 +400,7 @@ let generate_status_notification ~(job_log : (string * string) list) ~(cfg : Con
     job_log_lines ~n:10
     |> (function
          | [] -> None
-         | (job_log, content) :: _ -> Some (job_log, content))
-    |> Option.map (fun (job_log, content) ->
-           { title = Some job_log; value = sprintf "```%s```" content; short = false })
+         | (job_log, content) :: _ -> Some ([{ title = Some job_log; value = sprintf "```%s```" content; short = false }]))
   in
   let summary =
     let state_info =

--- a/test/slack_payloads.expected
+++ b/test/slack_payloads.expected
@@ -547,7 +547,7 @@ will notify #default
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: author/patches/js-storage"
+      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: author/patches/js-storage\n*Test on buildkite-agent-1.txt*\n```diff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\nindex 88404ca..a9e2880 100644\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n@@ -1,2 +1,2 @@\n   $ dune exec backend\n-  aaabvaaa\n+  aaaa\n🚨 Error: The command exited with status 1\n```"
     }
   ],
   "unfurl_links": false
@@ -561,7 +561,7 @@ will notify #id[author@ahrefs.com]
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: author/patches/js-storage"
+      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: author/patches/js-storage\n*Test on buildkite-agent-1.txt*\n```diff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\nindex 88404ca..a9e2880 100644\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n@@ -1,2 +1,2 @@\n   $ dune exec backend\n-  aaabvaaa\n+  aaaa\n🚨 Error: The command exited with status 1\n```"
     }
   ],
   "unfurl_links": false
@@ -596,7 +596,7 @@ will notify #default
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: author/patches/js-storage"
+      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: author/patches/js-storage\n*Test on buildkite-agent-1.txt*\n```diff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\nindex 88404ca..a9e2880 100644\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n@@ -1,2 +1,2 @@\n   $ dune exec backend\n-  aaabvaaa\n+  aaaa\n🚨 Error: The command exited with status 1\n```"
     }
   ],
   "unfurl_links": false
@@ -611,7 +611,7 @@ will notify #default
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: author/patches/js-storage"
+      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: author/patches/js-storage\n*Test on unknown.txt*\n```diff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\nindex 88404ca..a9e2880 100644\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n@@ -1,2 +1,2 @@\n   $ dune exec backend\n-  aaabvaaa\n+  aaaa\n🚨 Error: The command exited with status 1\n```"
     }
   ],
   "unfurl_links": false
@@ -626,7 +626,7 @@ will notify #all-push-events
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: develop"
+      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: develop\n*Test on buildkite-agent-1.txt*\n```diff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\nindex 88404ca..a9e2880 100644\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n@@ -1,2 +1,2 @@\n   $ dune exec backend\n-  aaabvaaa\n+  aaaa\n🚨 Error: The command exited with status 1\n```"
     }
   ],
   "unfurl_links": false
@@ -641,7 +641,7 @@ will notify #default
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: author/patches/js-storage"
+      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: author/patches/js-storage\n*Test on unknown.txt*\n```diff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\nindex 88404ca..a9e2880 100644\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n@@ -1,2 +1,2 @@\n   $ dune exec backend\n-  aaabvaaa\n+  aaaa\n🚨 Error: The command exited with status 1\n```"
     }
   ],
   "unfurl_links": false
@@ -656,7 +656,7 @@ will notify #all-push-events
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: develop"
+      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: develop\n*Test on unknown.txt*\n```diff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\nindex 88404ca..a9e2880 100644\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n@@ -1,2 +1,2 @@\n   $ dune exec backend\n-  aaabvaaa\n+  aaaa\n🚨 Error: The command exited with status 1\n```"
     }
   ],
   "unfurl_links": false
@@ -671,7 +671,7 @@ will notify #all-push-events
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: develop"
+      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: develop\n*Test on unknown.txt*\n```diff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\nindex 88404ca..a9e2880 100644\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n@@ -1,2 +1,2 @@\n   $ dune exec backend\n-  aaabvaaa\n+  aaaa\n🚨 Error: The command exited with status 1\n```"
     }
   ],
   "unfurl_links": false
@@ -701,7 +701,7 @@ will notify #all-push-events
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: develop"
+      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/7e0a933e9c71b4ca107680ca958ca1888d5e479b|7e0a933e>` author\n*Branch*: develop\n*Test on unknown.txt*\n```diff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\nindex 88404ca..a9e2880 100644\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n@@ -1,2 +1,2 @@\n   $ dune exec backend\n-  aaabvaaa\n+  aaaa\n🚨 Error: The command exited with status 1\n```"
     }
   ],
   "unfurl_links": false
@@ -716,7 +716,7 @@ will notify #default
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/0d95302addd66c1816bce1b1d495ed1c93ccd478|0d95302a>` Khady\n*Branch*: master"
+      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/0d95302addd66c1816bce1b1d495ed1c93ccd478|0d95302a>` Khady\n*Branch*: master\n*Test on unknown.txt*\n```diff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\nindex 88404ca..a9e2880 100644\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n@@ -1,2 +1,2 @@\n   $ dune exec backend\n-  aaabvaaa\n+  aaaa\n🚨 Error: The command exited with status 1\n```"
     }
   ],
   "unfurl_links": false
@@ -731,7 +731,7 @@ will notify #all-push-events
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/0d95302addd66c1816bce1b1d495ed1c93ccd478|0d95302a>` Khady\n*Branch*: develop"
+      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/0d95302addd66c1816bce1b1d495ed1c93ccd478|0d95302a>` Khady\n*Branch*: develop\n*Test on unknown.txt*\n```diff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\nindex 88404ca..a9e2880 100644\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n@@ -1,2 +1,2 @@\n   $ dune exec backend\n-  aaabvaaa\n+  aaaa\n🚨 Error: The command exited with status 1\n```"
     }
   ],
   "unfurl_links": false
@@ -746,7 +746,7 @@ will notify #default
       "fallback": null,
       "mrkdwn_in": [ "fields", "text" ],
       "color": "danger",
-      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/0d95302addd66c1816bce1b1d495ed1c93ccd478|0d95302a>` Khady\n*Branch*: master"
+      "text": "*Commit*: `<https://github.com/ahrefs/monorepo/commit/0d95302addd66c1816bce1b1d495ed1c93ccd478|0d95302a>` Khady\n*Branch*: master\n*Test on unknown.txt*\n```diff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\nindex 88404ca..a9e2880 100644\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n@@ -1,2 +1,2 @@\n   $ dune exec backend\n-  aaabvaaa\n+  aaaa\n🚨 Error: The command exited with status 1\n```"
     }
   ],
   "unfurl_links": false


### PR DESCRIPTION
@ygrek asked me to have a few lines of the error messages directly in the message. 

The reasoning is that most often, the error can be found in the last few lines.

The PR does not disable the longer logs in the reply afterwards.

I did not manage to test this. For some reason, in my test setup, failed logs don't trigger a message being sent. Has the way this should be configured changed ? I have not tested anything for a few months.