### PR TITLE
Add Buildkite Slack unfurls

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,14 @@ make dev ARGS="run -p 3000 --state=state.json"
 
 ### Link Unfurling
 
-You can configure Monorobot to [unfurl GitHub links](https://api.slack.com/reference/messaging/link-unfurling) in Slack messages. Currently, commit, pull request, and issue links are supported.
+You can configure Monorobot to [unfurl links](https://api.slack.com/reference/messaging/link-unfurling) in Slack messages. Currently, GitHub commit, pull request, issue, and compare links are supported, as well as Buildkite build links.
 
 Note: The `slack_access_token` must be configured in your secrets file for link unfurling. See previous section for details.
+Buildkite link unfurling also requires `buildkite_access_token` to fetch build and log details.
 
 1. Give your app `links:read` and `links:write` [permissions](https://api.slack.com/apps).
 1. Configure your app to [support the Events API](https://api.slack.com/events-api#prepare). During the [url verification handshake](https://api.slack.com/events-api#the-events-api__subscribing-to-event-types__events-api-request-urls__request-url-configuration--verification__url-verification-handshake), you should tell Slack to direct event notifications to `<server_domain>/slack/events`. Ensure the server is running before triggering the handshake.
-1. [Register the GitHub domains](https://api.slack.com/reference/messaging/link-unfurling#configuring_domains) you want to support.
+1. [Register the domains](https://api.slack.com/reference/messaging/link-unfurling#configuring_domains) you want to support, for example `github.com` and `buildkite.com`.
 
 ### Slack mentions
 

--- a/documentation/secret_docs.md
+++ b/documentation/secret_docs.md
@@ -105,9 +105,9 @@ Expected format:
 Refer [here](https://api.slack.com/messaging/webhooks) for obtaining a webhook for a channel.
 
 ## `buildkite_access_token`
-This token is used to get informations regarding builds details and components. It's required to use the failed builds notifications feature.
+This token is used to get information about build details, steps, and logs. It's required to use the failed builds notifications feature and to unfurl Buildkite build links in Slack.
 
-You also need to have one webhook configured on your pipelines with the `build.finished` scope. Configure the `buildkite_signing_secret` setting to validate the payloads if you require it.
+For failed build notifications, you also need to have one webhook configured on your pipelines with the `build.finished` scope. Configure the `buildkite_signing_secret` setting to validate the payloads if you require it.
 
 To manage your API access tokens, visit your [personal settings page](https://buildkite.com/user/api-access-tokens) where you can create or edit them.
 

--- a/lib/action.ml
+++ b/lib/action.ml
@@ -519,6 +519,16 @@ module Action (Github_api : Api.Github) (Slack_api : Api.Slack) (Buildkite_api :
         Lwt.return_none
     in
     let process link =
+      let fetch_buildkite_job_log (buildkite_link : Util.Build.buildkite_link) =
+        match buildkite_link.fragment with
+        | Some ({ job_id; lines = Some _ } : Util.Build.buildkite_fragment) ->
+          (match%lwt Buildkite_api.get_job_log_by_id ~ctx ~build_url:buildkite_link.build_url ~job_id with
+          | Ok job_log -> Lwt.return_some job_log
+          | Error msg ->
+            log#warn "failed to fetch job log from buildkite for %s: %s" link msg;
+            Lwt.return_none)
+        | _ -> Lwt.return_none
+      in
       let with_gh_result_populate_slack (type a) ~(api_result : (a, string) Result.t) ~populate ~repo =
         match api_result with
         | Error msg ->
@@ -527,7 +537,17 @@ module Action (Github_api : Api.Github) (Slack_api : Api.Slack) (Buildkite_api :
         | Ok item -> Lwt.return_some @@ (link, populate repo item)
       in
       match Github.gh_link_of_string link with
-      | None -> Lwt.return_none
+      | None ->
+        (match Util.Build.buildkite_link_of_string link with
+        | None -> Lwt.return_none
+        | Some buildkite_link ->
+          (match%lwt Buildkite_api.get_build ~ctx buildkite_link.build_url with
+          | Error msg ->
+            log#warn "failed to fetch info from buildkite for %s: %s" link msg;
+            Lwt.return_none
+          | Ok build ->
+            let%lwt job_log = fetch_buildkite_job_log buildkite_link in
+            Lwt.return_some (link, Slack_message.populate_buildkite_build ?job_log buildkite_link build)))
       | Some (repo, gh_resource) ->
       match gh_resource with
       | Pull_request number ->

--- a/lib/api.ml
+++ b/lib/api.ml
@@ -45,6 +45,10 @@ end
 module type Buildkite = sig
   val get_job_log :
     ctx:Context.t -> Github_t.status_notification -> Buildkite_t.job -> (Buildkite_t.job_log, string) result Lwt.t
+
+  val get_job_log_by_id :
+    ctx:Context.t -> build_url:string -> job_id:string -> (Buildkite_t.job_log, string) result Lwt.t
+
   val get_build_branch : ctx:Context.t -> Github_t.status_notification -> (Github_t.branch, string) Result.t Lwt.t
 
   val get_build :

--- a/lib/api_local.ml
+++ b/lib/api_local.ml
@@ -237,27 +237,58 @@ module Slack : Api.Slack = struct
 end
 
 module Buildkite : Api.Buildkite = struct
-  let get_job_log ~ctx:_ (_ : Github_t.status_notification) (job : Buildkite_t.job) =
+  let build_cache_file build_url =
+    let org, pipeline, build_nr = Util.Build.get_org_pipeline_build' build_url in
+    clean_forward_slashes (sprintf "organizations/%s/pipelines/%s/builds/%s" org pipeline build_nr)
+
+  let get_build_cache build_url =
+    let url = Filename.concat buildkite_cache_dir (build_cache_file build_url) in
+    with_cache_file url Buildkite_j.get_build_res_of_string
+
+  let job_log_cache_file ~org ~pipeline ~build_nr ~job_id =
+    clean_forward_slashes (sprintf "organizations/%s/pipelines/%s/builds/%s/jobs/%s/logs" org pipeline build_nr job_id)
+
+  let get_job_log_cache ~org ~pipeline ~build_nr ~job_id =
+    let url = Filename.concat buildkite_cache_dir (job_log_cache_file ~org ~pipeline ~build_nr ~job_id) in
+    with_cache_file url Buildkite_j.job_log_of_string
+
+  let get_job_log_by_id ~ctx:_ ~build_url ~job_id =
+    let org, pipeline, build_nr = Util.Build.get_org_pipeline_build' build_url in
+    let file = Filename.concat buildkite_cache_dir (job_log_cache_file ~org ~pipeline ~build_nr ~job_id) in
+    if Sys.file_exists file then get_job_log_cache ~org ~pipeline ~build_nr ~job_id
+    else
+      let* build = get_build_cache build_url in
+      match
+        List.find_map
+          (function
+            | Buildkite_t.Script ({ id; log_url; _ } : Buildkite_t.job)
+            | Trigger ({ id; log_url; _ } : Buildkite_t.job)
+              when String.equal id job_id -> log_url
+            | _ -> None)
+          build.jobs
+      with
+      | None -> Lwt.return_error (sprintf "Unable to get job log, job %s has no log_url field" job_id)
+      | Some log_url ->
+        (match Re2.find_submatches_exn Util.Build.buildkite_api_org_pipeline_build_job_re log_url with
+        | exception exn -> Exn.fail ~exn "failed to parse buildkite build url %s" log_url
+        | [| Some _; Some org; Some pipeline; Some build_nr; Some job_id |] ->
+          get_job_log_cache ~org ~pipeline ~build_nr ~job_id
+        | _ -> failwith "failed to get all job log details from the job.")
+
+  let get_job_log ~ctx (_n : Github_t.status_notification) (job : Buildkite_t.job) =
     match job.log_url with
     | None -> Lwt.return_error "Unable to get job log, job has no log_url field"
     | Some log_url ->
     match Re2.find_submatches_exn Util.Build.buildkite_api_org_pipeline_build_job_re log_url with
     | exception exn -> Exn.fail ~exn "failed to parse buildkite build url %s" log_url
     | [| Some _; Some org; Some pipeline; Some build_nr; Some job_nbr |] ->
-      let file =
-        clean_forward_slashes
-          (sprintf "organizations/%s/pipelines/%s/builds/%s/jobs/%s/logs" org pipeline build_nr job_nbr)
-      in
-      let url = Filename.concat buildkite_cache_dir file in
-      with_cache_file url Buildkite_j.job_log_of_string
+      let build_url = Util.Build.buildkite_build_url ~org ~pipeline ~build_nr () in
+      get_job_log_by_id ~ctx ~build_url ~job_id:job_nbr
     | _ -> failwith "failed to get all job log details from the job."
 
   [@@@warning "-27"]
   let get_build ?(cache : [ `Use | `Refresh ] option) ~ctx build_url =
-    let org, pipeline, build_nr = Util.Build.get_org_pipeline_build' build_url in
-    let file = clean_forward_slashes (sprintf "organizations/%s/pipelines/%s/builds/%s" org pipeline build_nr) in
-    let url = Filename.concat buildkite_cache_dir file in
-    with_cache_file url Buildkite_j.get_build_res_of_string
+    get_build_cache build_url
 
   let get_build_branch ~ctx (n : Github_t.status_notification) =
     let* build_url = Lwt.return @@ Util.Build.get_build_url n in

--- a/lib/api_remote.ml
+++ b/lib/api_remote.ml
@@ -372,10 +372,14 @@ module Buildkite : Api.Buildkite = struct
       buildkite_api_request ?body ~headers meth url read
       |> Lwt_result.map_error (fun e -> sprintf "%s: failure : %s" name e)
 
-  let get_job_log ~ctx n (job : Buildkite_t.job) =
-    let* org, pipeline, build_nr = Lwt.return @@ Util.Build.get_org_pipeline_build n in
-    let url = sprintf "organizations/%s/pipelines/%s/builds/%s/jobs/%s/log" org pipeline build_nr job.id in
+  let get_job_log_by_id ~ctx ~build_url ~job_id =
+    let org, pipeline, build_nr = Util.Build.get_org_pipeline_build' build_url in
+    let url = sprintf "organizations/%s/pipelines/%s/builds/%s/jobs/%s/log" org pipeline build_nr job_id in
     request_token_auth ~name:"get job logs" ~ctx `GET url Buildkite_j.job_log_of_string
+
+  let get_job_log ~ctx n (job : Buildkite_t.job) =
+    let* build_url = Lwt.return @@ Util.Build.get_build_url n in
+    get_job_log_by_id ~ctx ~build_url ~job_id:job.id
 
   let cache_key org pipeline build_nr = sprintf "%s/%s/%s" org pipeline build_nr
 

--- a/lib/slack_message.ml
+++ b/lib/slack_message.ml
@@ -220,3 +220,126 @@ let populate_compare repository (compare : compare) =
     let text = sprintf "%s%s" (String.concat "" commits_unfurl_text) file_stats in
     let fallback = String.concat "" commits_unfurl_fallback in
     { base with text = Some text; fallback = Some fallback }
+
+let buildkite_unfurl_line_cap = 50
+
+let color_of_buildkite_state (state : Buildkite_t.build_state) =
+  match state with
+  | Buildkite_t.Passed -> "good"
+  | Buildkite_t.Failed | Buildkite_t.Failing | Buildkite_t.Canceled | Buildkite_t.Canceling -> "danger"
+  | _ -> Colors.gray
+
+let string_of_buildkite_state : Buildkite_t.build_state -> string = function
+  | Blocked -> "blocked"
+  | Canceled -> "canceled"
+  | Canceling -> "canceling"
+  | Failed -> "failed"
+  | Failing -> "failing"
+  | Finished -> "finished"
+  | Not_run -> "not_run"
+  | Passed -> "passed"
+  | Running -> "running"
+  | Scheduled -> "scheduled"
+  | Skipped -> "skipped"
+  | Other state -> state
+
+let string_of_buildkite_job_state : Buildkite_t.job_state -> string = function
+  | Pending -> "pending"
+  | Waiting -> "waiting"
+  | Waiting_failed -> "waiting_failed"
+  | Blocked -> "blocked"
+  | Blocked_failed -> "blocked_failed"
+  | Unblocked -> "unblocked"
+  | Unblocked_failed -> "unblocked_failed"
+  | Limiting -> "limiting"
+  | Limited -> "limited"
+  | Scheduled -> "scheduled"
+  | Assigned -> "assigned"
+  | Accepted -> "accepted"
+  | Running -> "running"
+  | Finished -> "finished"
+  | Canceling -> "canceling"
+  | Canceled -> "canceled"
+  | Expired -> "expired"
+  | Timing_out -> "timing_out"
+  | Timed_out -> "timed_out"
+  | Skipped -> "skipped"
+  | Broken -> "broken"
+  | Passed -> "passed"
+  | Failed -> "failed"
+  | Other state -> state
+
+let find_buildkite_job jobs job_id =
+  List.find_map
+    (function
+      | Buildkite_t.Script ({ id; _ } as job) | Buildkite_t.Trigger ({ id; _ } as job) when String.equal id job_id ->
+        Some job
+      | _ -> None)
+    jobs
+
+let buildkite_log_field (lines : Util.Build.line_range) (job_log : Buildkite_t.job_log) =
+  let requested_len = lines.last_line - lines.first_line + 1 in
+  let truncated = requested_len > buildkite_unfurl_line_cap in
+  let last_line =
+    if truncated then lines.first_line + buildkite_unfurl_line_cap - 1 else lines.last_line
+  in
+  let selected_lines =
+    job_log.content |> Text_cleanup.cleanup |> String.split_on_char '\n'
+    |> List.mapi (fun idx line -> idx + 1, line)
+    |> List.filter_map (fun (line_nr, line) ->
+           if line_nr >= lines.first_line && line_nr <= last_line then Some line else None)
+  in
+  let title =
+    if lines.first_line = lines.last_line then sprintf "Log line %d" lines.first_line
+    else sprintf "Log lines %d-%d" lines.first_line lines.last_line
+  in
+  let value =
+    match selected_lines with
+    | [] -> "_No log lines found for requested range._"
+    | lines ->
+      sprintf "```%s```%s" (String.concat "\n" lines)
+        (if truncated then sprintf "\n_truncated to first %d requested lines_" buildkite_unfurl_line_cap else "")
+  in
+  { title = Some title; value; short = false }
+
+let populate_buildkite_build ?job_log (link : Util.Build.buildkite_link) (build : Buildkite_t.get_build_res) =
+  let state = string_of_buildkite_state build.state in
+  let pipeline_url = sprintf "https://buildkite.com/%s/%s" link.org link.pipeline in
+  let title = sprintf "buildkite/%s #%d %s" link.pipeline build.number state in
+  let job_lines =
+    match link.fragment with
+    | None -> []
+    | Some { job_id; _ } ->
+      (match find_buildkite_job build.jobs job_id with
+      | Some job ->
+        [
+          sprintf "*Step*: <%s|%s> (%s)" job.web_url (escape_mrkdwn job.name)
+            (string_of_buildkite_job_state job.state);
+        ]
+      | None -> [ sprintf "*Step*: `%s`" (escape_mrkdwn job_id) ])
+  in
+  let text =
+    [
+      [ sprintf "*Message*: %s" (escape_mrkdwn (Util.first_line build.message)) ];
+      [ sprintf "*Branch*: `%s`" (escape_mrkdwn build.branch) ];
+      [ sprintf "*Commit*: `%s`" (Slack.git_short_sha_hash build.sha) ];
+      job_lines;
+    ]
+    |> List.concat |> String.concat "\n"
+  in
+  let fields =
+    match link.fragment, job_log with
+    | Some { lines = Some lines; _ }, Some job_log -> Some [ buildkite_log_field lines job_log ]
+    | _ -> None
+  in
+  {
+    empty_attachment with
+    fallback = Some (sprintf "[buildkite/%s] Build #%d %s: %s" link.pipeline build.number state (Util.first_line build.message));
+    mrkdwn_in = Some [ "fields"; "text" ];
+    color = Some (color_of_buildkite_state build.state);
+    title = Some title;
+    title_link = Some link.original_url;
+    text = Some text;
+    fields;
+    footer = Some (sprintf "<%s|buildkite/%s>" pipeline_url (escape_mrkdwn link.pipeline));
+  }

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -44,6 +44,25 @@ module Build = struct
     pipeline_name : string;
   }
 
+  type line_range = {
+    first_line : int;
+    last_line : int;
+  }
+
+  type buildkite_fragment = {
+    job_id : string;
+    lines : line_range option;
+  }
+
+  type buildkite_link = {
+    original_url : string;
+    org : string;
+    pipeline : string;
+    build_nr : string;
+    build_url : string;
+    fragment : buildkite_fragment option;
+  }
+
   let buildkite_is_failed_re = Re2.create_exn {|^Build #\d+ failed|}
   let buildkite_is_failing_re = Re2.create_exn {|^Build #(\d+) is failing|}
   let buildkite_is_canceled_re = Re2.create_exn {|^Build #\d+ canceled by .+|}
@@ -66,6 +85,59 @@ module Build = struct
   let buildkite_pipeline_name_re =
     (* Gets the pipeline name from the buildkite context *)
     Re2.create_exn {|buildkite/([\w_-]+)|}
+
+  let buildkite_line_re = Re2.create_exn {|^L([0-9]+)(?:-L([0-9]+))?$|}
+
+  let buildkite_build_url ?(scheme = "https") ~org ~pipeline ~build_nr () =
+    sprintf "%s://buildkite.com/%s/%s/builds/%s" scheme org pipeline build_nr
+
+  let parse_buildkite_lines s =
+    match Re2.find_submatches_exn buildkite_line_re s with
+    | [| Some _; Some first_line; last_line |] ->
+      let first_line = int_of_string first_line in
+      let last_line = Option.map_default int_of_string first_line last_line in
+      if first_line > 0 && last_line >= first_line then Some { first_line; last_line } else None
+    | _ | (exception _) -> None
+
+  let parse_buildkite_fragment fragment =
+    match fragment |> Web.urldecode |> String.split_on_char '/' with
+    | [ job_id ] when job_id <> "" -> Some { job_id; lines = None }
+    | [ job_id; lines ] when job_id <> "" ->
+      Option.map (fun lines -> { job_id; lines = Some lines }) (parse_buildkite_lines lines)
+    | _ -> None
+
+  let buildkite_link_of_string url_str =
+    let url = Uri.of_string url_str in
+    match Uri.host url, Uri.path url with
+    | Some "buildkite.com", path when String.starts_with ~prefix:"/" path ->
+      let path =
+        Stre.drop_prefix path "/" |> flip Stre.drop_suffix "/" |> flip Stre.nsplitc '/' |> List.map Web.urldecode
+      in
+      (match path with
+      | [ org; pipeline; "builds"; build_nr ] -> begin
+        match int_of_string build_nr with
+        | exception _ -> None
+        | build_num when build_num <= 0 -> None
+        | _ ->
+          let fragment =
+            match Uri.fragment url with
+            | None -> Some None
+            | Some fragment -> Option.map (fun fragment -> Some fragment) (parse_buildkite_fragment fragment)
+          in
+          Option.map
+            (fun fragment ->
+              {
+                original_url = url_str;
+                org;
+                pipeline;
+                build_nr;
+                build_url = buildkite_build_url ?scheme:(Uri.scheme url) ~org ~pipeline ~build_nr ();
+                fragment;
+              })
+            fragment
+      end
+      | _ -> None)
+    | _ -> None
 
   let is_pipeline_step context = Re2.matches buildkite_is_step_re context
 

--- a/mock_slack_events/buildkite.build_only.json
+++ b/mock_slack_events/buildkite.build_only.json
@@ -1,0 +1,35 @@
+{
+  "token": "",
+  "team_id": "T0475L7BATY",
+  "api_app_id": "A047JBWSX26",
+  "event": {
+    "type": "link_shared",
+    "user": "U046XN0M2R5",
+    "channel": "C047QTRD1CH",
+    "message_ts": "1666757700.000001",
+    "links": [
+      {
+        "url": "https://buildkite.com/org/pipeline2/builds/181734",
+        "domain": "buildkite.com"
+      }
+    ],
+    "source": "conversations_history",
+    "unfurl_id": "C047QTRD1CH.1666757700.000001.buildkite",
+    "is_bot_user_member": false,
+    "event_ts": "1666757701.000001"
+  },
+  "type": "event_callback",
+  "event_id": "EvBUILD0001",
+  "event_time": 1666757701,
+  "authorizations": [
+    {
+      "enterprise_id": null,
+      "team_id": "T0475L7BATY",
+      "user_id": "U047X1F32SD",
+      "is_bot": true,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": "buildkite-build-only"
+}

--- a/mock_slack_events/buildkite.job_lines.json
+++ b/mock_slack_events/buildkite.job_lines.json
@@ -1,0 +1,35 @@
+{
+  "token": "",
+  "team_id": "T0475L7BATY",
+  "api_app_id": "A047JBWSX26",
+  "event": {
+    "type": "link_shared",
+    "user": "U046XN0M2R5",
+    "channel": "C047QTRD1CH",
+    "message_ts": "1666757700.000002",
+    "links": [
+      {
+        "url": "https://buildkite.com/org/pipeline2/builds/181734#01948e8b-5b5e-4e4a-9e0b-b8b64e381c90/L17-L21",
+        "domain": "buildkite.com"
+      }
+    ],
+    "source": "conversations_history",
+    "unfurl_id": "C047QTRD1CH.1666757700.000002.buildkite",
+    "is_bot_user_member": false,
+    "event_ts": "1666757701.000002"
+  },
+  "type": "event_callback",
+  "event_id": "EvBUILD0002",
+  "event_time": 1666757701,
+  "authorizations": [
+    {
+      "enterprise_id": null,
+      "team_id": "T0475L7BATY",
+      "user_id": "U047X1F32SD",
+      "is_bot": true,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": "buildkite-job-lines"
+}

--- a/mock_slack_events/buildkite.job_lines_cap.json
+++ b/mock_slack_events/buildkite.job_lines_cap.json
@@ -1,0 +1,35 @@
+{
+  "token": "",
+  "team_id": "T0475L7BATY",
+  "api_app_id": "A047JBWSX26",
+  "event": {
+    "type": "link_shared",
+    "user": "U046XN0M2R5",
+    "channel": "C047QTRD1CH",
+    "message_ts": "1666757700.000003",
+    "links": [
+      {
+        "url": "https://buildkite.com/org/pipeline2/builds/181734#01948e8b-5b5e-4e4a-9e0b-b8b64e381c90/L1-L60",
+        "domain": "buildkite.com"
+      }
+    ],
+    "source": "conversations_history",
+    "unfurl_id": "C047QTRD1CH.1666757700.000003.buildkite",
+    "is_bot_user_member": false,
+    "event_ts": "1666757701.000003"
+  },
+  "type": "event_callback",
+  "event_id": "EvBUILD0003",
+  "event_time": 1666757701,
+  "authorizations": [
+    {
+      "enterprise_id": null,
+      "team_id": "T0475L7BATY",
+      "user_id": "U047X1F32SD",
+      "is_bot": true,
+      "is_enterprise_install": false
+    }
+  ],
+  "is_ext_shared_channel": false,
+  "event_context": "buildkite-job-lines-cap"
+}

--- a/test/buildkite_link_test.ml
+++ b/test/buildkite_link_test.ml
@@ -1,0 +1,71 @@
+open Printf
+open Monorobotlib
+
+let job_id = "019e6dcb-4ec9-4c24-ad14-8a8099e30556"
+
+let lines first_line last_line = { Util.Build.first_line; last_line }
+let fragment ?lines job_id = { Util.Build.job_id; lines }
+
+let buildkite_link ?(original_url = "") ?(org = "ahrefs") ?(pipeline = "monorepo") ?fragment build_nr =
+  let original_url =
+    if original_url = "" then Util.Build.buildkite_build_url ~org ~pipeline ~build_nr () else original_url
+  in
+  {
+    Util.Build.original_url;
+    org;
+    pipeline;
+    build_nr;
+    build_url = Util.Build.buildkite_build_url ~org ~pipeline ~build_nr ();
+    fragment;
+  }
+
+let cases =
+  let build_url = "https://buildkite.com/ahrefs/monorepo/builds/327273" in
+  [
+    build_url, Some (buildkite_link "327273");
+    ( build_url ^ "?foo=bar",
+      Some (buildkite_link ~original_url:(build_url ^ "?foo=bar") "327273") );
+    ( build_url ^ "#" ^ job_id,
+      Some (buildkite_link ~original_url:(build_url ^ "#" ^ job_id) ~fragment:(fragment job_id) "327273") );
+    ( build_url ^ "#" ^ job_id ^ "/L2448",
+      Some
+        (buildkite_link
+           ~original_url:(build_url ^ "#" ^ job_id ^ "/L2448")
+           ~fragment:(fragment ~lines:(lines 2448 2448) job_id)
+           "327273") );
+    ( build_url ^ "#" ^ job_id ^ "/L2197-L2203",
+      Some
+        (buildkite_link
+           ~original_url:(build_url ^ "#" ^ job_id ^ "/L2197-L2203")
+           ~fragment:(fragment ~lines:(lines 2197 2203) job_id)
+           "327273") );
+    "https://example.com/ahrefs/monorepo/builds/327273", None;
+    "https://buildkite.com/ahrefs/monorepo", None;
+    "https://buildkite.com/ahrefs/monorepo/builds/nope", None;
+    build_url ^ "#" ^ job_id ^ "/L0", None;
+    build_url ^ "#" ^ job_id ^ "/L4-L2", None;
+  ]
+
+let output = function
+  | None -> "{None}"
+  | Some { Util.Build.original_url; org; pipeline; build_nr; build_url; fragment } ->
+    let fragment =
+      match fragment with
+      | None -> "none"
+      | Some { job_id; lines = None } -> sprintf "%s" job_id
+      | Some { job_id; lines = Some { first_line; last_line } } ->
+        sprintf "%s/L%d-L%d" job_id first_line last_line
+    in
+    sprintf "%s %s/%s/%s %s %s" original_url org pipeline build_nr build_url fragment
+
+let () =
+  List.iter
+    (fun (input, expected) ->
+      let got = Util.Build.buildkite_link_of_string input in
+      assert (
+        match got = expected with
+        | true -> true
+        | false ->
+          Printf.printf "for: %s | expected: %s but got %s" input (output expected) (output got);
+          false))
+    cases

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,5 @@
 (executables
- (names test github_link_test longest_prefix_test)
+ (names test github_link_test buildkite_link_test longest_prefix_test)
  (libraries monorobotlib devkit devkit.core extlib lwt.unix yojson)
  (preprocess
   (pps lwt_ppx)))
@@ -29,6 +29,11 @@
  (alias runtest)
  (action
   (run ./github_link_test.exe)))
+
+(rule
+ (alias runtest)
+ (action
+  (run ./buildkite_link_test.exe)))
 
 (rule
  (alias runtest)

--- a/test/slack_payloads.expected
+++ b/test/slack_payloads.expected
@@ -847,6 +847,69 @@ will notify #default
 }
 ===== file ../mock_payloads/status.success_test_main_branch.json =====
 ===== file ../mock_payloads/status.success_test_non_main_branch.json =====
+===== file ../mock_slack_events/buildkite.build_only.json =====
+will unfurl in #C047QTRD1CH
+{
+  "channel": "C047QTRD1CH",
+  "ts": "1666757700.000001",
+  "unfurls": {
+    "https://buildkite.com/org/pipeline2/builds/181734": {
+      "fallback": "[buildkite/pipeline2] Build #181734 failed: c1 message",
+      "mrkdwn_in": [ "fields", "text" ],
+      "color": "danger",
+      "title": "buildkite/pipeline2 #181734 failed",
+      "title_link": "https://buildkite.com/org/pipeline2/builds/181734",
+      "text": "*Message*: c1 message\n*Branch*: `develop`\n*Commit*: `51d7c2d0`",
+      "footer": "<https://buildkite.com/org/pipeline2|buildkite/pipeline2>"
+    }
+  }
+}
+===== file ../mock_slack_events/buildkite.job_lines.json =====
+will unfurl in #C047QTRD1CH
+{
+  "channel": "C047QTRD1CH",
+  "ts": "1666757700.000002",
+  "unfurls": {
+    "https://buildkite.com/org/pipeline2/builds/181734#01948e8b-5b5e-4e4a-9e0b-b8b64e381c90/L17-L21": {
+      "fallback": "[buildkite/pipeline2] Build #181734 failed: c1 message",
+      "mrkdwn_in": [ "fields", "text" ],
+      "color": "danger",
+      "title": "buildkite/pipeline2 #181734 failed",
+      "title_link": "https://buildkite.com/org/pipeline2/builds/181734#01948e8b-5b5e-4e4a-9e0b-b8b64e381c90/L17-L21",
+      "text": "*Message*: c1 message\n*Branch*: `develop`\n*Commit*: `51d7c2d0`\n*Step*: <https://buildkite.com/org/pipeline2/builds/181734#01948e8b-5b5e-4e4a-9e0b-b8b64e381c90|Test> (failed)",
+      "fields": [
+        {
+          "title": "Log lines 17-21",
+          "value": "```$ echo \"Test the rocket\"\ndune test\nexit 0\nTest the rocket\nFile \"tests/test.t\", line 1, characters 0-0:```"
+        }
+      ],
+      "footer": "<https://buildkite.com/org/pipeline2|buildkite/pipeline2>"
+    }
+  }
+}
+===== file ../mock_slack_events/buildkite.job_lines_cap.json =====
+will unfurl in #C047QTRD1CH
+{
+  "channel": "C047QTRD1CH",
+  "ts": "1666757700.000003",
+  "unfurls": {
+    "https://buildkite.com/org/pipeline2/builds/181734#01948e8b-5b5e-4e4a-9e0b-b8b64e381c90/L1-L60": {
+      "fallback": "[buildkite/pipeline2] Build #181734 failed: c1 message",
+      "mrkdwn_in": [ "fields", "text" ],
+      "color": "danger",
+      "title": "buildkite/pipeline2 #181734 failed",
+      "title_link": "https://buildkite.com/org/pipeline2/builds/181734#01948e8b-5b5e-4e4a-9e0b-b8b64e381c90/L1-L60",
+      "text": "*Message*: c1 message\n*Branch*: `develop`\n*Commit*: `51d7c2d0`\n*Step*: <https://buildkite.com/org/pipeline2/builds/181734#01948e8b-5b5e-4e4a-9e0b-b8b64e381c90|Test> (failed)",
+      "fields": [
+        {
+          "title": "Log lines 1-60",
+          "value": "```~~~ Preparing working directory\n$ cd /home/emile/.buildkite-agent/builds/emile-tarides-1/monorobot-test-org/monorobot-test-pipeline\nPseudo-terminal will not be allocated because stdin is not a terminal.\n# Host \"github.com\" already in list of known hosts at \"/home/emile/.ssh/known_hosts\"\n$ git clean -ffxdq\n$ git fetch -v --prune -- origin 404671053ebacf0245dc5b60566eb85e19465860\nFrom github.com:EmileTrotignon/monorobot_test\n * branch            404671053ebacf0245dc5b60566eb85e19465860 -> FETCH_HEAD\n$ git checkout -f 404671053ebacf0245dc5b60566eb85e19465860\nHEAD is now at 4046710 test change\n# Cleaning again to catch any post-checkout changes\n$ git clean -ffxdq\n# Checking to see if git commit information needs to be sent to Buildkite...\n$ buildkite-agent meta-data exists buildkite:git:commit\n# Git commit information has already been sent to Buildkite\n~~~ Running commands\n$ echo \"Test the rocket\"\ndune test\nexit 0\nTest the rocket\nFile \"tests/test.t\", line 1, characters 0-0:\n/usr/bin/git --no-pager diff --no-index --color=always -u _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t _build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\ndiff --git a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\nindex 88404ca..a9e2880 100644\n--- a/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t\n+++ b/_build/.sandbox/ca5ef14ba31cbcd6e129c4c5b8cdc872/default/tests/test.t.corrected\n@@ -1,2 +1,2 @@\n   $ dune exec backend\n-  aaabvaaa\n+  aaaa\n🚨 Error: The command exited with status 1\n```\n_truncated to first 50 requested lines_"
+        }
+      ],
+      "footer": "<https://buildkite.com/org/pipeline2|buildkite/pipeline2>"
+    }
+  }
+}
 ===== file ../mock_slack_events/commits.one_file_modified.json =====
 will unfurl in #C047QTRD1CH
 {


### PR DESCRIPTION
This PR has not been reviewed by a human yet

## Why
Buildkite build URLs currently do not get useful Slack unfurls, so pasted build links require opening Buildkite to see the build state, step context, or referenced log lines.

## What changed
- Add Buildkite build URL parsing, including job fragments and exact `/Lx-Ly` log line ranges.
- Fetch Buildkite build/job log details through the existing Buildkite API abstraction.
- Render Slack unfurls for Buildkite build links, with cleaned log snippets capped at 50 requested lines.
- Add parser and Slack fixture coverage, plus setup documentation for `buildkite.com` unfurls.

## Validation
- `opam exec --switch . -- dune runtest`
