### PR TITLE
slack: skip "pushed by" line for single-author merge-queue pushes

### DIFF
--- a/documentation/config_docs.md
+++ b/documentation/config_docs.md
@@ -18,6 +18,9 @@ Refer [here](https://docs.github.com/en/free-pro-team@latest/developers/webhooks
     "ignored_users": [
         "ignored_user"
     ],
+    "known_bot_pushers": [
+        "github-merge-queue[bot]"
+    ],
     "user_mappings": {
         "git.user@gitemail.com": "user1@slackemail.com",
         "gh-handle": "user2@slackemail.com"
@@ -54,6 +57,7 @@ Refer [here](https://docs.github.com/en/free-pro-team@latest/developers/webhooks
 | `status_rules` | status rules config object | all status notifications are ignored |
 | `project_owners` | project owners config object | no project owners are defined |
 | `ignored_users` | list of users to be ignored on all notifications | no user is ignored |
+| `known_bot_pushers` | bot pusher logins (e.g. `github-merge-queue[bot]`) whose single-author pushes skip the redundant "pushed by" line; multi-author pushes still get it | none |
 | `user_mappings` | list of mappings from git email and/or GitHub handle to Slack email | no mapping defined
 | `notifications_configs` | list of configs for certain types of notifications | dm_for_failing_build defaults to true and dm_after_failed_build to false
 | `include_logs_in_notifs` | when a build is failing, send error logs with the notification | true |

--- a/lib/action.ml
+++ b/lib/action.ml
@@ -329,7 +329,9 @@ module Action (Github_api : Api.Github) (Slack_api : Api.Slack) (Buildkite_api :
     | false ->
     match req with
     | Github.Push n ->
-      partition_push cfg n |> List.map (fun (channel, n) -> generate_push_notification n channel) |> Lwt.return
+      partition_push cfg n
+      |> List.map (fun (channel, n) -> generate_push_notification ~known_bot_pushers:cfg.known_bot_pushers n channel)
+      |> Lwt.return
     | Pull_request n ->
       partition_pr cfg ctx n |> List.map (generate_pull_request_notification ~ctx ~slack_match_func n) |> Lwt.return
     | PR_review n ->

--- a/lib/config.atd
+++ b/lib/config.atd
@@ -56,6 +56,7 @@ type config = {
   ~status_rules <ocaml default="{allowed_pipelines = Some []; rules = []}"> : status_rules;
   ~project_owners <ocaml default="{rules = []}"> : project_owners;
   ~ignored_users <ocaml default="[]">: string list; (* list of ignored users *)
+  ~known_bot_pushers <ocaml default="[]">: string list; (* sender logins (e.g. "github-merge-queue[bot]") whose single-author pushes are treated as analogous to a self-push, suppressing the redundant "pushed by <bot>" line; batched pushes folding multiple authors' commits still get the line *)
   ?main_branch_name : string nullable; (* the name of the main branch; used to filter out notifications about merges of main branch into other branches *)
   ~user_mappings <ocaml default="[]">: (string * string) list <json repr="object">; (* list of github to slack profile mappings *)
   ~notifications_configs <ocaml default="{dm_after_failed_build = []; dm_for_failing_build = []}"> : notifications_configs;

--- a/lib/slack.ml
+++ b/lib/slack.ml
@@ -298,7 +298,7 @@ let pp_list_with_previews ~pp_item list =
   end
   else List.map pp_item list
 
-let generate_push_notification notification channel =
+let generate_push_notification ~known_bot_pushers notification channel =
   let { sender; pusher; created; deleted; forced; compare; commits; repository; _ } = notification in
   let show_descriptive_title_min_commits = 4 in
   let branch_name = Github.commits_branch_of_ref notification.ref in
@@ -310,12 +310,19 @@ let generate_push_notification notification channel =
   | false ->
     let commits_preview_lines = pp_list_with_previews ~pp_item:pp_commit commits in
     let num_commits = List.length commits in
+    (* A bot pusher (e.g. the merge queue) is never a commit author, so compare against the push's own author instead. *)
+    let reference_author_email =
+      match commits with
+      | hd :: _ when List.exists (String.equal sender.login) known_bot_pushers -> hd.author.email
+      | _ -> pusher.email
+    in
+    let all_commits_by_reference_author = List.for_all (fun c -> c.author.email = reference_author_email) commits in
     let lines =
       if
         num_commits < show_descriptive_title_min_commits
         && (not forced)
         && (not created)
-        && List.for_all (fun commit -> commit.author.email = pusher.email) commits
+        && all_commits_by_reference_author
       then commits_preview_lines
       else begin
         let compare =

--- a/mock_payloads/push.merge_queue.json
+++ b/mock_payloads/push.merge_queue.json
@@ -1,0 +1,55 @@
+{
+  "ref": "refs/heads/main",
+  "created": false,
+  "deleted": false,
+  "forced": false,
+  "after": "b2c3d4e5f60718293a4b5c6d7e8f900112233445",
+  "compare": "https://github.com/org/repo/compare/7fbe59ab63e6...2f239e604610",
+  "repository": {
+    "name": "repo",
+    "full_name": "org/repo",
+    "html_url": "https://github.com/org/repo",
+    "commits_url": "https://api.github.com/repos/org/repo/commits{/sha}",
+    "contents_url": "https://api.github.com/repos/org/repo/contents/{+path}",
+    "pulls_url": "https://api.github.com/repos/org/repo/pulls{/number}",
+    "issues_url": "https://api.github.com/repos/org/repo/issues{/number}",
+    "compare_url": "https://api.github.com/repos/org/repo/compare/{base}...{head}"
+  },
+  "pusher": {
+    "name": "github-merge-queue[bot]",
+    "email": "118344674+github-merge-queue[bot]@users.noreply.github.com"
+  },
+  "sender": {
+    "login": "github-merge-queue[bot]",
+    "id": 118344674,
+    "url": "https://api.github.com/users/github-merge-queue%5Bbot%5D",
+    "html_url": "https://github.com/apps/github-merge-queue",
+    "avatar_url": "https://avatars.githubusercontent.com/u/222?v=4"
+  },
+  "commits": [
+    {
+      "id": "a1b2c3d4e5f60718293a4b5c6d7e8f9001122334",
+      "distinct": true,
+      "message": "Update readme (#16)",
+      "timestamp": "2025-03-05T15:14:15Z",
+      "url": "https://github.com/org/repo/commit/a1b2c3d4e5f60718293a4b5c6d7e8f9001122334",
+      "author": { "name": "User Name", "email": "user@users.noreply.github.com" },
+      "committer": { "name": "GitHub" },
+      "added": [],
+      "removed": [],
+      "modified": ["README.md"]
+    },
+    {
+      "id": "b2c3d4e5f60718293a4b5c6d7e8f900112233445",
+      "distinct": true,
+      "message": "Add TESTING.md (#17)",
+      "timestamp": "2025-03-05T15:14:15Z",
+      "url": "https://github.com/org/repo/commit/b2c3d4e5f60718293a4b5c6d7e8f900112233445",
+      "author": { "name": "User Name", "email": "user@users.noreply.github.com" },
+      "committer": { "name": "GitHub" },
+      "added": ["TESTING.md"],
+      "removed": [],
+      "modified": []
+    }
+  ]
+}

--- a/mock_payloads/push.merge_queue_multi_author.json
+++ b/mock_payloads/push.merge_queue_multi_author.json
@@ -1,0 +1,55 @@
+{
+  "ref": "refs/heads/main",
+  "created": false,
+  "deleted": false,
+  "forced": false,
+  "after": "c3d4e5f6071829394b5c6d7e8f90011223344556",
+  "compare": "https://github.com/org/repo/compare/7fbe59ab63e6...2f239e604610",
+  "repository": {
+    "name": "repo",
+    "full_name": "org/repo",
+    "html_url": "https://github.com/org/repo",
+    "commits_url": "https://api.github.com/repos/org/repo/commits{/sha}",
+    "contents_url": "https://api.github.com/repos/org/repo/contents/{+path}",
+    "pulls_url": "https://api.github.com/repos/org/repo/pulls{/number}",
+    "issues_url": "https://api.github.com/repos/org/repo/issues{/number}",
+    "compare_url": "https://api.github.com/repos/org/repo/compare/{base}...{head}"
+  },
+  "pusher": {
+    "name": "github-merge-queue[bot]",
+    "email": "118344674+github-merge-queue[bot]@users.noreply.github.com"
+  },
+  "sender": {
+    "login": "github-merge-queue[bot]",
+    "id": 118344674,
+    "url": "https://api.github.com/users/github-merge-queue%5Bbot%5D",
+    "html_url": "https://github.com/apps/github-merge-queue",
+    "avatar_url": "https://avatars.githubusercontent.com/u/222?v=4"
+  },
+  "commits": [
+    {
+      "id": "a1b2c3d4e5f60718293a4b5c6d7e8f9001122334",
+      "distinct": true,
+      "message": "Update readme (#16)",
+      "timestamp": "2025-03-05T15:14:15Z",
+      "url": "https://github.com/org/repo/commit/a1b2c3d4e5f60718293a4b5c6d7e8f9001122334",
+      "author": { "name": "User Name", "email": "user@users.noreply.github.com" },
+      "committer": { "name": "GitHub" },
+      "added": [],
+      "removed": [],
+      "modified": ["README.md"]
+    },
+    {
+      "id": "c3d4e5f6071829394b5c6d7e8f90011223344556",
+      "distinct": true,
+      "message": "Add TESTING.md (#17)",
+      "timestamp": "2025-03-05T15:14:15Z",
+      "url": "https://github.com/org/repo/commit/c3d4e5f6071829394b5c6d7e8f90011223344556",
+      "author": { "name": "Second User", "email": "second@users.noreply.github.com" },
+      "committer": { "name": "GitHub" },
+      "added": ["TESTING.md"],
+      "removed": [],
+      "modified": []
+    }
+  ]
+}

--- a/test/monorobot.json
+++ b/test/monorobot.json
@@ -39,6 +39,7 @@
     ]
   },
   "ignored_users": ["ignored_user"],
+  "known_bot_pushers": ["github-merge-queue[bot]"],
   "prefix_rules": {
     "default_channel": "default",
     "filter_main_branch": true,

--- a/test/slack_payloads.expected
+++ b/test/slack_payloads.expected
@@ -518,6 +518,22 @@ will notify #default
   "text": "`<https://github.com/org/repo/commit/2f929e604610c6b1c6830439c0bbe927cb553eb5|2f239e60>` Very important changes on very important files (<https://github.com/org/repo/pull/16|#16>) - User Name",
   "unfurl_links": false
 }
+===== file ../mock_payloads/push.merge_queue.json =====
+will notify #default
+{
+  "channel": "default",
+  "username": "repo:main",
+  "text": "`<https://github.com/org/repo/commit/a1b2c3d4e5f60718293a4b5c6d7e8f9001122334|a1b2c3d4>` Update readme (<https://github.com/org/repo/pull/16|#16>) - User Name\n`<https://github.com/org/repo/commit/b2c3d4e5f60718293a4b5c6d7e8f900112233445|b2c3d4e5>` Add TESTING.md (<https://github.com/org/repo/pull/17|#17>) - User Name",
+  "unfurl_links": false
+}
+===== file ../mock_payloads/push.merge_queue_multi_author.json =====
+will notify #default
+{
+  "channel": "default",
+  "username": "repo:main",
+  "text": "<https://github.com/org/repo/compare/7fbe59ab63e6...2f239e604610|2 commits> pushed by github-merge-queue[bot]\n`<https://github.com/org/repo/commit/a1b2c3d4e5f60718293a4b5c6d7e8f9001122334|a1b2c3d4>` Update readme (<https://github.com/org/repo/pull/16|#16>) - User Name\n`<https://github.com/org/repo/commit/c3d4e5f6071829394b5c6d7e8f90011223344556|c3d4e5f6>` Add TESTING.md (<https://github.com/org/repo/pull/17|#17>) - Second User",
+  "unfurl_links": false
+}
 ===== file ../mock_payloads/push.two_commits_longest_match.json =====
 will notify #all-push-events
 {


### PR DESCRIPTION
Merge-queue merges are attributed to `github-merge-queue[bot]` as the pusher, so the condition that commit author equals pusher never holds, and the "N commits pushed by github-merge-queue[bot]" line always shows. 

We add a configurable `known_bot_pushers` list (other names welcome?) whose pushes show that line only when the commits come from more than one author, instead of when the author differs from the pusher. A single PR merged by the queue now renders as just the commit previews, while a batched push spanning multiple authors still gets the line.

### How to test

Two tests added, `push.merge_queue.json` and `push.merge_queue_multi_author.json`
