### PR TITLE
Support multiple pipeline owners for build-failure mentions

### DIFF
--- a/documentation/config_docs.md
+++ b/documentation/config_docs.md
@@ -205,7 +205,7 @@ Internally, the bot keeps track of the status of the last allowed payload, for a
         "failed_builds_channel": "failed-builds",
         "name": "buildkite/monorobot-test",
         "notify_canceled_builds": false,
-        "pipeline_owner": "owner@example.com",
+        "pipeline_owners": ["owner1@example.com", "owner2@example.com"],
         "mention_owner_on_failed_builds": true
       }
     ],
@@ -227,6 +227,8 @@ Internally, the bot keeps track of the status of the last allowed payload, for a
 }
 ```
 
+> **Note:** the singular `"pipeline_owner": "x@y.com"` field is **deprecated** in favour of `pipeline_owners`, but still accepted. If both are set on the same pipeline, they are merged.
+
 | value | description | default |
 |-|-|-|
 | `rules` | a list of **status rules** to determine whether to *allow* or *ignore* a payload for further processing | required field |
@@ -241,9 +243,10 @@ Internally, the bot keeps track of the status of the last allowed payload, for a
 | `notify_canceled_builds` | canceled builds with new failed steps will be notified like failed builds unless `notify_canceled_builds` is set to false. | false
 | `mention_user_on_failed_builds` | wether monorobot will @mention the author of the commit on failed builds notifications | true
 | `escalate_notifications` | if failed steps haven't been fixed after a certain period of time, notify again on the next failed build and @mention the original author of the commit that broke that/those steps | false
-| `escalate_notifications_threshold` | period in hours after which monorobot should start escalating notifications | 2
-| `pipeline_owner` | email address of the pipeline owner. When set together with `mention_owner_on_failed_builds`, the owner will be @mentioned in failed build notifications | empty
-| `mention_owner_on_failed_builds` | whether monorobot will @mention the pipeline owner on failed build notifications. Requires `pipeline_owner` to be set. This is independent of `mention_user_on_failed_builds` — both the commit author and the pipeline owner can be mentioned simultaneously if both options are enabled | false
+| `escalate_notification_threshold` | period in hours after which monorobot should start escalating notifications | 2
+| `pipeline_owners` | a list of email addresses of the pipeline owners. When set together with `mention_owner_on_failed_builds`, the owners will be @mentioned in failed build notifications. | empty
+| `pipeline_owner` | **deprecated** — use `pipeline_owners` instead. A single email address of a pipeline owner. If both `pipeline_owner` and `pipeline_owners` are set on the same pipeline, they are merged. | empty
+| `mention_owner_on_failed_builds` | whether monorobot will @mention the pipeline owners on failed build notifications. Requires `pipeline_owners` (or the deprecated `pipeline_owner`) to be non-empty. This is independent of `mention_user_on_failed_builds` — both the commit author and the pipeline owners can be mentioned simultaneously if both options are enabled | false
 
 ### Status Rules
 

--- a/lib/action.ml
+++ b/lib/action.ml
@@ -741,11 +741,9 @@ module Action (Github_api : Api.Github) (Slack_api : Api.Slack) (Buildkite_api :
                      Lwt_list.map_s to_slack_id author_emails
                  in
                  let%lwt owner_slack_ids =
-                   match mention_owner_on_failed_builds cfg n, pipeline_owner cfg n with
-                   | true, Some owner_email ->
-                     let%lwt id = to_slack_id owner_email in
-                     Lwt.return [ id ]
-                   | _ -> Lwt.return []
+                   match mention_owner_on_failed_builds cfg n with
+                   | true -> Lwt_list.map_s to_slack_id (pipeline_owners cfg n)
+                   | false -> Lwt.return []
                  in
                  let slack_ids = List.filter_map Fun.id (user_slack_ids @ owner_slack_ids) in
                  let slack_ids = List.sort_uniq compare slack_ids in

--- a/lib/config.atd
+++ b/lib/config.atd
@@ -14,7 +14,8 @@ type pipeline = {
   (* threshold in hours *)
   ~escalate_notification_threshold <ocaml default="2">: int;
   ~dm_users_on_failures <ocaml default="true">: bool;
-  ?pipeline_owner: string nullable;
+  ?pipeline_owner: string nullable; (* deprecated: use pipeline_owners instead. Merged with pipeline_owners when both are set. *)
+  ~pipeline_owners <ocaml default="[]">: string list;
   ~mention_owner_on_failed_builds <ocaml default="false">: bool;
 } <json adapter.ocaml="Atd_adapters.Strings_to_pipelines_adapter">
 

--- a/lib/util.ml
+++ b/lib/util.ml
@@ -398,8 +398,15 @@ module Webhook = struct
     get_pipeline_config cfg n
     |> Option.map_default (fun (config : Config_t.pipeline) -> config.mention_owner_on_failed_builds) false
 
-  let pipeline_owner (cfg : Config_t.config) (n : n) =
-    get_pipeline_config cfg n |> Option.map_default (fun (config : Config_t.pipeline) -> config.pipeline_owner) None
+  (* merge the deprecated singular [pipeline_owner] with [pipeline_owners] *)
+  let merged_pipeline_owners (config : Config_t.pipeline) =
+    let owners = config.pipeline_owners in
+    match config.pipeline_owner with
+    | Some owner when not (List.mem owner owners) -> owner :: owners
+    | Some _ | None -> owners
+
+  let pipeline_owners (cfg : Config_t.config) (n : n) =
+    get_pipeline_config cfg n |> Option.map_default merged_pipeline_owners []
 
   let get_escalation_threshold (cfg : Config_t.config) (n : n) =
     match get_pipeline_config cfg n with

--- a/test/dune
+++ b/test/dune
@@ -1,5 +1,5 @@
 (executables
- (names test github_link_test longest_prefix_test)
+ (names test github_link_test longest_prefix_test pipeline_owners_test)
  (libraries monorobotlib devkit devkit.core extlib lwt.unix yojson)
  (preprocess
   (pps lwt_ppx)))
@@ -34,3 +34,8 @@
  (alias runtest)
  (action
   (run ./longest_prefix_test.exe)))
+
+(rule
+ (alias runtest)
+ (action
+  (run ./pipeline_owners_test.exe)))

--- a/test/pipeline_owners_test.ml
+++ b/test/pipeline_owners_test.ml
@@ -1,0 +1,31 @@
+open Monorobotlib
+
+(* base pipeline with no owners; individual tests override the owner fields *)
+let base_pipeline : Config_t.pipeline =
+  {
+    name = "buildkite/test";
+    failed_builds_channel = None;
+    notify_canceled_builds = false;
+    mention_user_on_failed_builds = true;
+    escalate_notifications = false;
+    escalate_notification_threshold = 2;
+    dm_users_on_failures = true;
+    pipeline_owner = None;
+    pipeline_owners = [];
+    mention_owner_on_failed_builds = false;
+  }
+
+let merged pipeline_owner pipeline_owners =
+  Util.Webhook.merged_pipeline_owners { base_pipeline with pipeline_owner; pipeline_owners }
+
+let () =
+  (* neither field set *)
+  assert (merged None [] = []);
+  (* only the deprecated singular field set *)
+  assert (merged (Some "a@x.com") [] = [ "a@x.com" ]);
+  (* only the plural field set *)
+  assert (merged None [ "a@x.com"; "b@x.com" ] = [ "a@x.com"; "b@x.com" ]);
+  (* both set, disjoint: singular is prepended to the plural list *)
+  assert (merged (Some "a@x.com") [ "b@x.com"; "c@x.com" ] = [ "a@x.com"; "b@x.com"; "c@x.com" ]);
+  (* both set, singular already present in plural: no duplicate *)
+  assert (merged (Some "a@x.com") [ "a@x.com"; "b@x.com" ] = [ "a@x.com"; "b@x.com" ])


### PR DESCRIPTION
## What

Adds support for **multiple pipeline owners** on build-failure notifications, while keeping the existing single-owner config working.

- New `pipeline_owners: string list` field on a pipeline config.
- The old `pipeline_owner: string` field is **kept but deprecated** — no config migration/adapter needed.
- When **both** are set on the same pipeline, they are **merged** (the deprecated singular value is prepended to the list, deduped) before resolving owner mentions.
- When `mention_owner_on_failed_builds` is enabled, all merged owners are @mentioned on failed-build notifications (deduped against the commit-author mentions downstream, as before).

## Also

- Fixes a pre-existing docs typo: `escalate_notifications_threshold` → `escalate_notification_threshold`, matching the actual config field name (the documented spelling would silently fall back to the 2h default).

## Testing

- Adds `test/pipeline_owners_test.ml`, a unit test for the owner-merge logic covering: neither field set, singular only, plural only, both disjoint (prepend), and both overlapping (dedup).
- `dune build` and `dune runtest` pass.

## Backwards compatibility

Existing configs using only `pipeline_owner` continue to work unchanged — the field is optional and still read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)