### PR TITLE
action: honor ignored_users for PR review events

### DIFF
--- a/lib/action.ml
+++ b/lib/action.ml
@@ -275,16 +275,15 @@ module Action (Github_api : Api.Github) (Slack_api : Api.Slack) (Buildkite_api :
   let ignore_notifications_from_user cfg req =
     let sender_login =
       match req with
-      | Github.Issue_comment n ->
-        Some n.sender.login
-        (*
-          | Github.Push n -> Some n.sender.login
-          | Pull_request n -> Some n.sender.login
-          | PR_review n -> Some n.sender.login
-          | PR_review_comment n -> Some n.sender.login
-          | Issue n -> Some n.sender.login
-          | Commit_comment n -> Some n.sender.login
-        *)
+      | Github.Issue_comment n -> Some n.sender.login
+      | PR_review n -> Some n.sender.login
+      | PR_review_comment n -> Some n.sender.login
+      (*
+        | Github.Push n -> Some n.sender.login
+        | Pull_request n -> Some n.sender.login
+        | Issue n -> Some n.sender.login
+        | Commit_comment n -> Some n.sender.login
+      *)
       | _ -> None
     in
     match sender_login with


### PR DESCRIPTION
`ignore_notifications_from_user` only matched `Issue_comment`, so `pull_request_review` and `pull_request_review_comment` events from users listed in `ignored_users` were still forwarded to Slack. In practice this means bot's reviews and inline review comments are posted to Slack channels even though they are marked as ignored in the config.